### PR TITLE
Fix travis to push develop as docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` > /tmp/docker-compose
   - chmod +x /tmp/docker-compose
   - sudo mv /tmp/docker-compose /usr/local/bin
-  - VERSION=$([ -z "${TRAVIS_TAG}" ] && echo "${TRAVIS_TAG#*v}" || echo "${TRAVIS_BRANCH##*/}")
+  - VERSION=$([ -n "${TRAVIS_TAG}" ] && echo "${TRAVIS_TAG#*v}" || echo "${TRAVIS_BRANCH##*/}")
 
 install:
   - git clone https://github.com/FAForever/faf-stack.git faf-stack
@@ -30,7 +30,7 @@ after_success:
   - ./gradlew jacocoTestReport coveralls
   - export IMAGE_TAG=faf-java-api;
   - export REPO=faforever/faf-java-api;
-  - if [ -n "${TRAVIS_TAG}" ]; then
+  - if [ -n "${TRAVIS_TAG}" || "${TRAVIS_BRANCH}" == "develop" ]; then
     docker build -t ${IMAGE_TAG} . &&
     echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin &&
     docker tag ${IMAGE_TAG} ${REPO}:${VERSION} &&
@@ -38,12 +38,6 @@ after_success:
     fi
 # TODO Codacy coverage reporter does not yet support Java 9. See https://github.com/codacy/codacy-coverage-reporter/issues/76
 #      ./gradlew sendCoverageToCodacy;
-  - if [ "${TRAVIS_BRANCH}" == "develop" ]; then
-    docker build -t ${IMAGE_TAG} . &&
-    echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin &&
-    docker tag ${IMAGE_TAG} ${REPO}:${VERSION} &&
-    docker push ${REPO};
-    fi
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
I noticed that develop is not pushed to docker (anymore?).

The `VERSION` variable was derived incorrect on branch pushes. However I don't understand why it worked with tags.
The docker push code was redundant.