### PR TITLE
Expose `gameReviewsSummary` as Elide root

### DIFF
--- a/src/main/java/com/faforever/api/data/domain/GameReviewsSummary.java
+++ b/src/main/java/com/faforever/api/data/domain/GameReviewsSummary.java
@@ -16,7 +16,7 @@ import javax.persistence.Table;
 @Entity
 @Setter
 @Table(name = "game_reviews_summary")
-@Include(type = "gameReviewsSummary")
+@Include(rootLevel = true, type = "gameReviewsSummary")
 @Immutable
 public class GameReviewsSummary {
   private int id;


### PR DESCRIPTION
Since not every game has a review summary, querying games and sorting
by review score is very inefficient. This way, the review summaries can
be queried directly.