### PR TITLE
 Add request id context to logging and error responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 install:
   - git clone https://github.com/FAForever/faf-stack.git faf-stack
       && pushd faf-stack
-    && git checkout 572bef1c
+    && git checkout 0eb5b8f610e5d5ba6bccc6eebca31148414135bd
       && cp -r config.template config
       && ./scripts/init-db.sh
       && popd

--- a/src/main/java/com/faforever/api/error/ErrorJsonSerializer.java
+++ b/src/main/java/com/faforever/api/error/ErrorJsonSerializer.java
@@ -1,8 +1,10 @@
 package com.faforever.api.error;
 
+import com.faforever.api.logging.RequestIdFilter;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import org.slf4j.MDC;
 import org.springframework.boot.jackson.JsonComponent;
 
 import java.io.IOException;
@@ -16,6 +18,7 @@ public class ErrorJsonSerializer extends JsonSerializer<Error> {
 
     gen.writeStartObject();
     gen.writeNumberField("code", errorCode.getCode());
+    gen.writeStringField("requestId", MDC.get(RequestIdFilter.REQUEST_ID_KEY));
     gen.writeStringField("title", MessageFormat.format(errorCode.getTitle(), error.getArgs()));
     gen.writeStringField("detail", MessageFormat.format(errorCode.getDetail(), error.getArgs()));
     gen.writeObjectField("args", error.getArgs());

--- a/src/main/java/com/faforever/api/error/ErrorResponse.java
+++ b/src/main/java/com/faforever/api/error/ErrorResponse.java
@@ -1,12 +1,20 @@
 package com.faforever.api.error;
 
+import com.faforever.api.logging.RequestIdFilter;
 import lombok.Data;
+import org.slf4j.MDC;
 
 import java.util.ArrayList;
 
 @Data
 public class ErrorResponse {
+  private final String requestId;
+
   private final ArrayList<ErrorResult> errors = new ArrayList<>();
+
+  public ErrorResponse() {
+    requestId = MDC.get(RequestIdFilter.REQUEST_ID_KEY);
+  }
 
   public ErrorResponse addError(ErrorResult newError) {
     errors.add(newError);

--- a/src/main/java/com/faforever/api/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/faforever/api/error/GlobalControllerExceptionHandler.java
@@ -61,7 +61,7 @@ class GlobalControllerExceptionHandler {
   @ExceptionHandler(NotFoundApiException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ResponseBody
-  public ErrorResponse processValidationException(NotFoundApiException ex) {
+  public ErrorResponse processNotFoundException(NotFoundApiException ex) {
     log.debug("Entity could not be found", ex);
     return createResponseFromApiException(ex, HttpStatus.NOT_FOUND);
   }

--- a/src/main/java/com/faforever/api/logging/RequestIdFilter.java
+++ b/src/main/java/com/faforever/api/logging/RequestIdFilter.java
@@ -1,0 +1,72 @@
+package com.faforever.api.logging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * This logging interceptor sets up the MDC with the external request id (if present) or a random UUID otherwise.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
+public class RequestIdFilter implements Filter {
+
+  /**
+   * Use this key in your log pattern and for fetching they request id from MDC.
+   */
+  public static final String REQUEST_ID_KEY = "requestId";
+  /**
+   * The default request id header. Change this if you configured a different key.
+   */
+  private static final String REQUEST_ID_HEADER = "X-Request-ID";
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    String requestId = null;
+
+    if (request instanceof HttpServletRequest) {
+      HttpServletRequest httpRequest = (HttpServletRequest) request;
+      requestId = httpRequest.getHeader(REQUEST_ID_HEADER);
+    }
+
+    if (StringUtils.isBlank(requestId)) {
+      requestId = UUID.randomUUID().toString();
+      log.trace("No header value found for key '{}'. Fallback to random UUID: {}", REQUEST_ID_HEADER, requestId);
+    } else {
+      log.trace("Request id read from header key '{}': {}", REQUEST_ID_HEADER, requestId);
+    }
+
+    MDC.put(REQUEST_ID_KEY, requestId);
+    log.trace("Adding request id key '{}' to logging context", REQUEST_ID_KEY);
+
+    try {
+      chain.doFilter(request, response);
+    } finally {
+      log.trace("Removing request id key '{}' from logging context", REQUEST_ID_KEY);
+      MDC.remove(REQUEST_ID_KEY);
+    }
+  }
+
+  @Override
+  public void destroy() {
+  }
+
+}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -78,5 +78,7 @@ management:
       exposure:
         include: '*'
 logging:
+  pattern:
+    console: "%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%36.36X{requestId:- no request context}]){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"
   level:
     com.faforever: ${LOG_LEVEL:info}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -9,7 +9,7 @@ faf-api:
   challonge:
     key: ${CHALLONGE_KEY:}
   database:
-    schema-version: ${DATABASE_SCHEMA_VERSION:66}
+    schema-version: ${DATABASE_SCHEMA_VERSION:67}
   mautic:
     base-url: ${MAUTIC_BASE_URL:false}
     client-id: ${MAUTIC_CLIENT_ID:false}


### PR DESCRIPTION
Each http request creates a request id (either from nginx or random uuid).
This request id is then applied to every log message during processing until the http request is finished, then it is cleaned up.
Furthermore the request id is added to each error message the API sends back to the client. So the user has an id that he can give on error reports to check the related logs.