### PR TITLE
WIP: Migrate all @Entity annotations from property to field level

### DIFF
--- a/src/main/java/com/faforever/api/client/OAuthClient.java
+++ b/src/main/java/com/faforever/api/client/OAuthClient.java
@@ -1,5 +1,7 @@
 package com.faforever.api.client;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.util.Assert;
@@ -12,70 +14,47 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
-
 @Entity
 @Table(name = "oauth_clients")
+@Getter
 @Setter
 public class OAuthClient {
 
-  private String id;
-  private String name;
-  private String clientSecret;
-  private ClientType clientType;
-  private String redirectUris;
-  private String defaultRedirectUri;
-  private String defaultScope;
-  private String iconUrl;
-  private Boolean autoApproveScopes;
-
   @Id
   @Column(name = "id")
-  public String getId() {
-    return id;
-  }
+  private String id;
 
   @NotNull
   @Column(name = "name")
-  public String getName() {
-    return name;
-  }
+  private String name;
 
   @NotNull
   @Column(name = "client_secret")
-  public String getClientSecret() {
-    return clientSecret;
-  }
+  private String clientSecret;
 
   @NotNull
   @Column(name = "client_type")
-  public ClientType getClientType() {
-    return clientType;
-  }
+  private ClientType clientType;
 
   @NotNull
   @Column(name = "redirect_uris")
-  public String getRedirectUris() {
-    return redirectUris;
-  }
+  private String redirectUris;
 
   @NotNull
   @Column(name = "default_redirect_uri")
-  public String getDefaultRedirectUri() {
-    return defaultRedirectUri;
-  }
+  private String defaultRedirectUri;
 
   @NotNull
   @Column(name = "default_scope")
-  public String getDefaultScope() {
-    return defaultScope;
-  }
+  private String defaultScope;
 
   @Column(name = "icon_url")
-  public String getIconUrl() {
-    return iconUrl;
-  }
+  private String iconUrl;
 
+  @Getter(AccessLevel.NONE) // for type Boolean Lombok generates get* method, not is*
   @Column(name = "auto_approve_scopes")
+  private Boolean autoApproveScopes;
+
   @Nullable
   public Boolean isAutoApproveScopes() {
     return autoApproveScopes;

--- a/src/main/java/com/faforever/api/data/domain/AbstractEntity.java
+++ b/src/main/java/com/faforever/api/data/domain/AbstractEntity.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -11,29 +12,21 @@ import javax.persistence.MappedSuperclass;
 import java.time.OffsetDateTime;
 
 @MappedSuperclass
+@Getter
 @Setter
 @EqualsAndHashCode(of = "id")
 public abstract class AbstractEntity {
-  protected int id;
-  protected OffsetDateTime createTime;
-  protected OffsetDateTime updateTime;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  protected int id;
 
   @Column(name = "create_time")
-  public OffsetDateTime getCreateTime() {
-    return createTime;
-  }
+  protected OffsetDateTime createTime;
 
   @Column(name = "update_time")
-  public OffsetDateTime getUpdateTime() {
-    return updateTime;
-  }
+  protected OffsetDateTime updateTime;
 
   /**
    * Supplement method for @EqualsAndHashCode overriding the default lombok implementation

--- a/src/main/java/com/faforever/api/data/domain/Achievement.java
+++ b/src/main/java/com/faforever/api/data/domain/Achievement.java
@@ -4,6 +4,7 @@ import com.faforever.api.data.listeners.AchievementLocalizationListener;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -24,132 +25,74 @@ import java.time.OffsetDateTime;
 @SecondaryTable(name = "achievement_statistics", pkJoinColumns = @PrimaryKeyJoinColumn(name = "achievement_id", referencedColumnName = "id"))
 @Include(rootLevel = true, type = Achievement.TYPE_NAME)
 @EntityListeners(AchievementLocalizationListener.class)
+@Getter
 @Setter
 public class Achievement {
 
   public static final String TYPE_NAME = "achievement";
 
-  private String id;
-  private int order;
-  private String nameKey;
-  private String descriptionKey;
-  private AchievementType type;
-  private Integer totalSteps;
-  private String revealedIconUrl;
-  private String unlockedIconUrl;
-  private AchievementState initialState;
-  private int experiencePoints;
-  private OffsetDateTime createTime;
-  private OffsetDateTime updateTime;
-  private long unlockersCount;
-  private BigDecimal unlockersPercent;
-  private Long unlockersMinDuration;
-  private Long unlockersAvgDuration;
-  private Long unlockersMaxDuration;
-
-  // Set by AchievementLocalizationListener
-  private String name;
-  private String description;
-
   @Id
   @Column(name = "id")
-  public String getId() {
-    return id;
-  }
+  private String id;
 
   @Column(name = "\"order\"")
-  public int getOrder() {
-    return order;
-  }
+  private int order;
 
   @Column(name = "name_key")
   @Exclude
-  public String getNameKey() {
-    return nameKey;
-  }
-
-  @Transient
-  @ComputedAttribute
-  public String getName() {
-    return name;
-  }
+  private String nameKey;
 
   @Column(name = "description_key")
   @Exclude
-  public String getDescriptionKey() {
-    return descriptionKey;
-  }
-
-  @Transient
-  @ComputedAttribute
-  public String getDescription() {
-    return description;
-  }
+  private String descriptionKey;
 
   @Column(name = "type")
   @Enumerated(EnumType.STRING)
-  public AchievementType getType() {
-    return type;
-  }
+  private AchievementType type;
 
   @Column(name = "total_steps")
-  public Integer getTotalSteps() {
-    return totalSteps;
-  }
+  private Integer totalSteps;
 
   @Column(name = "revealed_icon_url")
-  public String getRevealedIconUrl() {
-    return revealedIconUrl;
-  }
+  private String revealedIconUrl;
 
   @Column(name = "unlocked_icon_url")
-  public String getUnlockedIconUrl() {
-    return unlockedIconUrl;
-  }
+  private String unlockedIconUrl;
 
   @Column(name = "initial_state")
   @Enumerated(value = EnumType.STRING)
-  public AchievementState getInitialState() {
-    return initialState;
-  }
+  private AchievementState initialState;
 
   @Column(name = "experience_points")
-  public int getExperiencePoints() {
-    return experiencePoints;
-  }
+  private int experiencePoints;
 
   @Column(name = "create_time")
-  public OffsetDateTime getCreateTime() {
-    return createTime;
-  }
+  private OffsetDateTime createTime;
 
   @Column(name = "update_time")
-  public OffsetDateTime getUpdateTime() {
-    return updateTime;
-  }
+  private OffsetDateTime updateTime;
 
   @Column(name = "unlockers_count", table = "achievement_statistics")
-  public long getUnlockersCount() {
-    return unlockersCount;
-  }
+  private long unlockersCount;
 
   @Column(name = "unlockers_percent", table = "achievement_statistics")
-  public BigDecimal getUnlockersPercent() {
-    return unlockersPercent;
-  }
+  private BigDecimal unlockersPercent;
 
   @Column(name = "unlockers_min_duration", table = "achievement_statistics")
-  public Long getUnlockersMinDuration() {
-    return unlockersMinDuration;
-  }
+  private Long unlockersMinDuration;
 
   @Column(name = "unlockers_avg_duration", table = "achievement_statistics")
-  public Long getUnlockersAvgDuration() {
-    return unlockersAvgDuration;
-  }
+  private Long unlockersAvgDuration;
 
   @Column(name = "unlockers_max_duration", table = "achievement_statistics")
-  public Long getUnlockersMaxDuration() {
-    return unlockersMaxDuration;
-  }
+  private Long unlockersMaxDuration;
+
+  // Set by AchievementLocalizationListener
+  @Transient
+  @ComputedAttribute
+  private String name;
+
+  @Transient
+  @ComputedAttribute
+  private String description;
 }

--- a/src/main/java/com/faforever/api/data/domain/Avatar.java
+++ b/src/main/java/com/faforever/api/data/domain/Avatar.java
@@ -4,6 +4,7 @@ import com.faforever.api.data.checks.permission.IsModerator;
 import com.github.jasminb.jsonapi.annotations.Type;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.CascadeType;
@@ -17,34 +18,24 @@ import java.util.List;
 @Entity
 @Table(name = "avatars_list")
 @Include(rootLevel = true, type = Avatar.TYPE_NAME)
+@Getter
 @Setter
 @Type(Avatar.TYPE_NAME)
 public class Avatar extends AbstractEntity {
 
   public static final String TYPE_NAME = "avatar";
 
-  private String url;
-  private String tooltip;
-  private List<AvatarAssignment> assignments;
-
   @Column(name = "url")
   @NotNull
-  public String getUrl() {
-    return url;
-  }
+  private String url;
 
   @Column(name = "tooltip")
   @UpdatePermission(expression = IsModerator.EXPRESSION)
-  public String getTooltip() {
-    return tooltip;
-  }
+  private String tooltip;
 
   // Cascading is needed for Create & Delete
   @OneToMany(mappedBy = "avatar", cascade = CascadeType.ALL, orphanRemoval = true)
   // Permission is managed by AvatarAssignment class
   @UpdatePermission(expression = "Prefab.Role.All")
-  public List<AvatarAssignment> getAssignments() {
-    return this.assignments;
-  }
-
+  private List<AvatarAssignment> assignments;
 }

--- a/src/main/java/com/faforever/api/data/domain/AvatarAssignment.java
+++ b/src/main/java/com/faforever/api/data/domain/AvatarAssignment.java
@@ -10,6 +10,8 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -29,46 +31,39 @@ import java.time.OffsetDateTime;
 @DeletePermission(expression = IsModerator.EXPRESSION)
 @Audit(action = Action.CREATE, logStatement = "Avatar ''{0}'' has been assigned to player ''{1}''", logExpressions = {"${avatarAssignment.avatar.id}", "${avatarAssignment.player.id}"})
 @Audit(action = Action.DELETE, logStatement = "Avatar ''{0}'' has been revoked from player ''{1}''", logExpressions = {"${avatarAssignment.avatar.id}", "${avatarAssignment.player.id}"})
+@Getter
 @Setter
 @Type(AvatarAssignment.TYPE_NAME)
 public class AvatarAssignment extends AbstractEntity implements OwnableEntity {
   public static final String TYPE_NAME = "avatarAssignment";
 
-  private Boolean selected = Boolean.FALSE;
-  private OffsetDateTime expiresAt;
-  @Relationship(Player.TYPE_NAME)
-  private Player player;
-  @Relationship(Avatar.TYPE_NAME)
-  private Avatar avatar;
-
+  @Getter(AccessLevel.NONE) // for type Boolean Lombok generates get* method, not is*
   @Column(name = "selected")
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION)
   @Audit(action = Action.UPDATE, logStatement = "Avatar ''{0}'' has been selected on player ''{1}''", logExpressions = {"${avatarAssignment.avatar.id}", "${avatarAssignment.player.id}"})
-  public Boolean isSelected() {
-    return selected;
-  }
+  private Boolean selected = Boolean.FALSE;
 
   @Column(name = "expires_at")
   @UpdatePermission(expression = IsModerator.EXPRESSION + " or Prefab.Common.UpdateOnCreate")
   @Audit(action = Action.UPDATE, logStatement = "Expiration of avatar assignment ''{0}'' has been set to ''{1}''", logExpressions = {"${avatarAssignment.id}", "${avatarAssignment.expiresAt}"})
-  public OffsetDateTime getExpiresAt() {
-    return expiresAt;
-  }
+  private OffsetDateTime expiresAt;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "idAvatar")
-  @NotNull
-  @UpdatePermission(expression = "Prefab.Common.UpdateOnCreate")
-  public Avatar getAvatar() {
-    return avatar;
-  }
-
+  @Relationship(Player.TYPE_NAME)
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "idUser")
   @NotNull
   @UpdatePermission(expression = "Prefab.Common.UpdateOnCreate")
-  public Player getPlayer() {
-    return player;
+  private Player player;
+
+  @Relationship(Avatar.TYPE_NAME)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "idAvatar")
+  @NotNull
+  @UpdatePermission(expression = "Prefab.Common.UpdateOnCreate")
+  private Avatar avatar;
+
+  public Boolean isSelected() {
+    return selected;
   }
 
   @Override

--- a/src/main/java/com/faforever/api/data/domain/BanInfo.java
+++ b/src/main/java/com/faforever/api/data/domain/BanInfo.java
@@ -13,6 +13,7 @@ import com.yahoo.elide.annotation.OnUpdatePreSecurity;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.core.RequestScope;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -36,76 +37,50 @@ import java.time.OffsetDateTime;
 @UpdatePermission(expression = HasBanUpdate.EXPRESSION)
 @Audit(action = Action.CREATE, logStatement = "Applied ban with id `{0}` for player `{1}`", logExpressions = {"${banInfo.id}", "${banInfo.player}"})
 @Audit(action = Action.UPDATE, logStatement = "Updated ban with id `{0}` for player `{1}`", logExpressions = {"${banInfo.id}", "${banInfo.player}"})
+@Getter
 @Setter
 public class BanInfo extends AbstractEntity {
-  private Player player;
-  private Player author;
-  private String reason;
-  private OffsetDateTime expiresAt;
-  private BanLevel level;
-  private ModerationReport moderationReport;
-  private String revokeReason;
-  private Player revokeAuthor;
-  private OffsetDateTime revokeTime;
 
   @ManyToOne
   @JoinColumn(name = "player_id")
   @NotNull
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @ManyToOne
   @UpdatePermission(expression = "Prefab.Role.None")
   @JoinColumn(name = "author_id")
   @NotNull
-  public Player getAuthor() {
-    return author;
-  }
+  private Player author;
 
   @Column(name = "reason")
   @NotNull
-  public String getReason() {
-    return reason;
-  }
+  private String reason;
 
   @Column(name = "expires_at")
-  public OffsetDateTime getExpiresAt() {
-    return expiresAt;
-  }
+  private OffsetDateTime expiresAt;
 
   @Column(name = "level")
   @Enumerated(EnumType.STRING)
-  public BanLevel getLevel() {
-    return level;
-  }
+  private BanLevel level;
 
   @ManyToOne
   @JoinColumn(name = "report_id")
-  public ModerationReport getModerationReport() {
-    return moderationReport;
-  }
-
-  @Transient
-  public BanDurationType getDuration() {
-    return expiresAt == null ? BanDurationType.PERMANENT : BanDurationType.TEMPORARY;
-  }
+  private ModerationReport moderationReport;
 
   @Column(name = "revoke_reason")
-  public String getRevokeReason() {
-    return revokeReason;
-  }
+  private String revokeReason;
 
   @ManyToOne
   @UpdatePermission(expression = "Prefab.Role.None")
   @JoinColumn(name = "revoke_author_id")
-  public Player getRevokeAuthor() {
-    return revokeAuthor;
-  }
+  private Player revokeAuthor;
 
   @Column(name = "revoke_time")
-  public OffsetDateTime getRevokeTime() {
-    return revokeTime;
+  private OffsetDateTime revokeTime;
+
+  @Transient
+  public BanDurationType getDuration() {
+    return expiresAt == null ? BanDurationType.PERMANENT : BanDurationType.TEMPORARY;
   }
 
   @Transient

--- a/src/main/java/com/faforever/api/data/domain/Clan.java
+++ b/src/main/java/com/faforever/api/data/domain/Clan.java
@@ -9,8 +9,8 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -22,6 +22,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
@@ -32,6 +33,7 @@ import java.util.List;
 @SharePermission
 @DeletePermission(expression = IsEntityOwner.EXPRESSION)
 @CreatePermission(expression = "Prefab.Role.All")
+@Getter
 @Setter
 @IsLeaderInClan
 @EntityListeners(ClanEnricherListener.class)
@@ -39,68 +41,43 @@ public class Clan extends AbstractEntity implements OwnableEntity {
 
   public static final String TYPE_NAME = "clan";
 
-  private String name;
-  private String tag;
-  private Player founder;
-  private Player leader;
-  private String description;
-  private String tagColor;
-  private String websiteUrl;
-  private List<ClanMembership> memberships;
-
   @Column(name = "name")
   @NotNull
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION)
-  public String getName() {
-    return name;
-  }
+  private String name;
 
   @Column(name = "tag")
   @Size(max = 3)
   @NotNull
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION)
-  public String getTag() {
-    return tag;
-  }
+  private String tag;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "founder_id")
-  public Player getFounder() {
-    return founder;
-  }
+  private Player founder;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "leader_id")
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION)
-  public Player getLeader() {
-    return leader;
-  }
+  private Player leader;
 
   @Column(name = "description")
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION)
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @Column(name = "tag_color")
-  public String getTagColor() {
-    return tagColor;
-  }
+  private String tagColor;
+
+  @Transient
+  @ComputedAttribute
+  private String websiteUrl;
 
   // Cascading is needed for Create & Delete
   @OneToMany(mappedBy = "clan", cascade = CascadeType.ALL, orphanRemoval = true)
   // Permission is managed by ClanMembership class
   @UpdatePermission(expression = "Prefab.Role.All")
   @NotEmpty(message = "At least the leader should be in the clan")
-  public List<ClanMembership> getMemberships() {
-    return this.memberships;
-  }
-
-  @Transient
-  @ComputedAttribute
-  public String getWebsiteUrl() {
-    return websiteUrl;
-  }
+  private List<ClanMembership> memberships;
 
   @Override
   @Transient

--- a/src/main/java/com/faforever/api/data/domain/ClanMembership.java
+++ b/src/main/java/com/faforever/api/data/domain/ClanMembership.java
@@ -3,6 +3,7 @@ package com.faforever.api.data.domain;
 import com.faforever.api.data.checks.IsClanMembershipDeletable;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
@@ -15,21 +16,15 @@ import javax.persistence.Table;
 @Table(name = "clan_membership")
 @Include(rootLevel = true, type = "clanMembership")
 @DeletePermission(expression = IsClanMembershipDeletable.EXPRESSION)
+@Getter
 @Setter
 public class ClanMembership extends AbstractEntity {
 
-  private Clan clan;
-  private Player player;
-
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "clan_id")
-  public Clan getClan() {
-    return clan;
-  }
+  private Clan clan;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "player_id")
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 }

--- a/src/main/java/com/faforever/api/data/domain/CoopMap.java
+++ b/src/main/java/com/faforever/api/data/domain/CoopMap.java
@@ -4,6 +4,7 @@ import com.faforever.api.data.listeners.CoopMapEnricher;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -19,77 +20,47 @@ import javax.persistence.Transient;
 @Table(name = "coop_map")
 @EntityListeners(CoopMapEnricher.class)
 @Include(rootLevel = true, type = "coopMission")
+@Getter
 @Setter
 public class CoopMap {
 
+  @Id
+  @Column(name = "id")
   private int id;
-  private MissionType category;
-  private String name;
-  private String description;
-  private Integer version;
-  private String filename;
-  // Set by CoopMapEnhancer
-  private String downloadUrl;
-  private String thumbnailUrlLarge;
-  private String thumbnailUrlSmall;
-  private String folderName;
 
   @Column(name = "type")
   @Enumerated(EnumType.ORDINAL)
-  public MissionType getCategory() {
-    return category;
-  }
-
-  @Id
-  @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private MissionType category;
 
   @Column(name = "name")
-  public String getName() {
-    return name;
-  }
+  private String name;
 
   @Column(name = "description")
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @Column(name = "version")
-  public Integer getVersion() {
-    return version;
-  }
+  private Integer version;
 
   @Column(name = "filename")
   @Exclude
-  public String getFilename() {
-    return filename;
-  }
+  private String filename;
+
+  // Set by CoopMapEnhancer
+  @Transient
+  @ComputedAttribute
+  private String downloadUrl;
 
   @Transient
   @ComputedAttribute
-  public String getDownloadUrl() {
-    return downloadUrl;
-  }
+  private String thumbnailUrlLarge;
 
   @Transient
   @ComputedAttribute
-  public String getThumbnailUrlLarge() {
-    return thumbnailUrlLarge;
-  }
+  private String thumbnailUrlSmall;
 
   @Transient
   @ComputedAttribute
-  public String getThumbnailUrlSmall() {
-    return thumbnailUrlSmall;
-  }
-
-  @Transient
-  @ComputedAttribute
-  public String getFolderName() {
-    return folderName;
-  }
+  private String folderName;
 
   private enum MissionType {
     FA, AEON, CYBRAN, UEF, CUSTOM

--- a/src/main/java/com/faforever/api/data/domain/CoopResult.java
+++ b/src/main/java/com/faforever/api/data/domain/CoopResult.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -14,48 +15,30 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "coop_leaderboard")
 @Include(rootLevel = true, type = CoopResult.TYPE_NAME)
+@Getter
 @Setter
 public class CoopResult {
 
   public static final String TYPE_NAME = "coopResult";
 
-  private int id;
-  private short mission;
-  private Game game;
-  private boolean secondaryObjectives;
-  private long duration;
-  private short playerCount;
-
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "mission")
-  public short getMission() {
-    return mission;
-  }
+  private short mission;
 
   @OneToOne
   @JoinColumn(name = "gameuid")
-  public Game getGame() {
-    return game;
-  }
+  private Game game;
 
   @Column(name = "secondary")
-  public boolean getSecondaryObjectives() {
-    return secondaryObjectives;
-  }
+  private boolean secondaryObjectives;
 
   @Column(name = "time")
   @Convert(converter = TimeConverter.class)
-  public long getDuration() {
-    return duration;
-  }
+  private long duration;
 
   @Column(name = "player_count")
-  public short getPlayerCount() {
-    return playerCount;
-  }
+  private short playerCount;
 }

--- a/src/main/java/com/faforever/api/data/domain/Division.java
+++ b/src/main/java/com/faforever/api/data/domain/Division.java
@@ -21,30 +21,18 @@ import javax.persistence.Table;
 @EqualsAndHashCode(of = "id")
 @ToString(of = {"id", "league", "name", "threshold"}, includeFieldNames = false)
 public class Division {
-  private int id;
-  private String name;
-  private int league;
-  private int threshold;
 
   @Id
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "name", nullable = false)
-  public String getName() {
-    return name;
-  }
+  private String name;
 
   @Column(name = "league")
-  public int getLeague() {
-    return league;
-  }
+  private int league;
 
   @Column(name = "threshold")
-  public int getThreshold() {
-    return threshold;
-  }
+  private int threshold;
 }

--- a/src/main/java/com/faforever/api/data/domain/DomainBlacklist.java
+++ b/src/main/java/com/faforever/api/data/domain/DomainBlacklist.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -17,6 +18,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 @Entity
+@Getter
 @Setter
 @Table(name = "email_domain_blacklist")
 @Include(type = "domainBlacklist", rootLevel = true)
@@ -28,15 +30,8 @@ import javax.persistence.Table;
 @Audit(action = Action.DELETE, logStatement = "Email domain `{0}` removed from blacklist", logExpressions = "${domainBlacklist.domain}")
 @EqualsAndHashCode
 public class DomainBlacklist {
-  private String domain;
 
   @Id
   @Column(name = "domain")
-  public String getDomain() {
-    return domain;
-  }
-
-  public void setDomain(String domain) {
-    this.domain = domain;
-  }
+  private String domain;
 }

--- a/src/main/java/com/faforever/api/data/domain/Event.java
+++ b/src/main/java/com/faforever/api/data/domain/Event.java
@@ -4,6 +4,7 @@ import com.faforever.api.data.listeners.EventLocalizationListener;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -18,48 +19,32 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = "event_definitions")
 @Include(rootLevel = true, type = Event.TYPE_NAME)
+@Getter
 @Setter
 @EntityListeners(EventLocalizationListener.class)
 public class Event {
 
   public static final String TYPE_NAME = "event";
 
-  private String id;
-  private String nameKey;
-  private String imageUrl;
-  private Type type;
-
-  // Set by EventLocalizationListener
-  private String name;
-
   @Id
   @Column(name = "id")
-  public String getId() {
-    return id;
-  }
+  private String id;
 
   @Column(name = "name_key")
   @Exclude
-  public String getNameKey() {
-    return nameKey;
-  }
-
-  @Transient
-  @ComputedAttribute
-  public String getName() {
-    return name;
-  }
+  private String nameKey;
 
   @Column(name = "image_url")
-  public String getImageUrl() {
-    return imageUrl;
-  }
+  private String imageUrl;
 
   @Column(name = "type")
   @Enumerated(EnumType.STRING)
-  public Type getType() {
-    return type;
-  }
+  private Type type;
+
+  // Set by EventLocalizationListener
+  @Transient
+  @ComputedAttribute
+  private String name;
 
   public enum Type {
     NUMERIC, TIME

--- a/src/main/java/com/faforever/api/data/domain/FeaturedMod.java
+++ b/src/main/java/com/faforever/api/data/domain/FeaturedMod.java
@@ -2,6 +2,8 @@ package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Include;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -14,84 +16,53 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = "game_featuredMods")
 @Include(rootLevel = true, type = FeaturedMod.TYPE_NAME)
+@Getter
 @Setter
 @EntityListeners(FeaturedModEnricher.class)
 public class FeaturedMod {
   public static final String TYPE_NAME = "featuredMod";
 
-  private int id;
-  private String technicalName;
-  private String description;
-  private String displayName;
-  private boolean visible;
-  private int order;
-  private String gitUrl;
-  private String gitBranch;
-  private Boolean allowOverride;
-  private String fileExtension;
-  private String bireusUrl;
-  private String deploymentWebhook;
-
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "gamemod")
-  public String getTechnicalName() {
-    return technicalName;
-  }
+  private String technicalName;
 
   @Column(name = "description")
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @Column(name = "name")
-  public String getDisplayName() {
-    return displayName;
-  }
+  private String displayName;
 
   @Column(name = "publish")
-  public boolean isVisible() {
-    return visible;
-  }
+  private boolean visible;
 
   @Column(name = "\"order\"")
-  public int getOrder() {
-    return order;
-  }
+  private int order;
 
   @Column(name = "git_url")
-  public String getGitUrl() {
-    return gitUrl;
-  }
+  private String gitUrl;
 
   @Column(name = "git_branch")
-  public String getGitBranch() {
-    return gitBranch;
-  }
+  private String gitBranch;
 
+  @Getter(AccessLevel.NONE) // for type Boolean Lombok generates get* method, not is*
   @Column(name = "allow_override")
-  public Boolean isAllowOverride() {
-    return allowOverride;
-  }
+  private Boolean allowOverride;
 
   @Column(name = "file_extension")
-  public String getFileExtension() {
-    return fileExtension;
-  }
+  private String fileExtension;
 
   @Column(name = "deployment_webhook ")
-  public String getDeploymentWebhook() {
-    return deploymentWebhook;
-  }
+  private String deploymentWebhook;
 
+  // Enriched by FeaturedModEnricher
   @Transient
   @ComputedAttribute
-  // Enriched by FeaturedModEnricher
-  public String getBireusUrl() {
-    return bireusUrl;
+  private String bireusUrl;
+
+  public Boolean isAllowOverride() {
+    return allowOverride;
   }
 }

--- a/src/main/java/com/faforever/api/data/domain/Game.java
+++ b/src/main/java/com/faforever/api/data/domain/Game.java
@@ -4,6 +4,7 @@ import com.faforever.api.data.listeners.GameEnricher;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Immutable;
@@ -30,97 +31,58 @@ import java.util.List;
 @Table(name = "game_stats")
 @Include(rootLevel = true, type = "game")
 @Immutable
+@Getter
 @Setter
 @EntityListeners(GameEnricher.class)
 public class Game {
 
-  private int id;
-  private OffsetDateTime startTime;
-  private OffsetDateTime endTime;
-  private VictoryCondition victoryCondition;
-  private FeaturedMod featuredMod;
-  private Player host;
-  private MapVersion mapVersion;
-  private String name;
-  private Validity validity;
-  private List<GamePlayerStats> playerStats;
-  private String replayUrl;
-  private List<GameReview> reviews;
-  private GameReviewsSummary reviewsSummary;
-
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "startTime")
-  public OffsetDateTime getStartTime() {
-    return startTime;
-  }
-
-  @Column(name = "gameType")
-  public VictoryCondition getVictoryCondition() {
-    return victoryCondition;
-  }
-
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "gameMod")
-  public FeaturedMod getFeaturedMod() {
-    return featuredMod;
-  }
-
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "host")
-  public Player getHost() {
-    return host;
-  }
-
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "mapId")
-  public MapVersion getMapVersion() {
-    return mapVersion;
-  }
-
-  @Column(name = "gameName")
-  public String getName() {
-    return name;
-  }
-
-  @Column(name = "validity")
-  @Enumerated(EnumType.ORDINAL)
-  public Validity getValidity() {
-    return validity;
-  }
-
-  @OneToMany(mappedBy = "game")
-  public List<GamePlayerStats> getPlayerStats() {
-    return playerStats;
-  }
+  private OffsetDateTime startTime;
 
   @Column(name = "endTime")
   @Nullable
-  public OffsetDateTime getEndTime() {
-    return endTime;
-  }
+  private OffsetDateTime endTime;
+
+  @Column(name = "gameType")
+  private VictoryCondition victoryCondition;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "gameMod")
+  private FeaturedMod featuredMod;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "host")
+  private Player host;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "mapId")
+  private MapVersion mapVersion;
+
+  @Column(name = "gameName")
+  private String name;
+
+  @Column(name = "validity")
+  @Enumerated(EnumType.ORDINAL)
+  private Validity validity;
+
+  @OneToMany(mappedBy = "game")
+  private List<GamePlayerStats> playerStats;
 
   @Transient
   @ComputedAttribute
-  public String getReplayUrl() {
-    return replayUrl;
-  }
+  private String replayUrl;
 
   @OneToMany(mappedBy = "game")
   @UpdatePermission(expression = "Prefab.Role.All")
-  public List<GameReview> getReviews() {
-    return reviews;
-  }
+  private List<GameReview> reviews;
 
   @OneToOne(fetch = FetchType.LAZY)
   @PrimaryKeyJoinColumn
   @UpdatePermission(expression = "Prefab.Role.All")
   @BatchSize(size = 1000)
-  public GameReviewsSummary getReviewsSummary() {
-    return reviewsSummary;
-  }
+  private GameReviewsSummary reviewsSummary;
 }

--- a/src/main/java/com/faforever/api/data/domain/GamePlayerStats.java
+++ b/src/main/java/com/faforever/api/data/domain/GamePlayerStats.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Immutable;
 
@@ -17,94 +18,52 @@ import java.time.OffsetDateTime;
 @Table(name = "game_player_stats")
 @Include(rootLevel = true, type = "gamePlayerStats")
 @Immutable
+@Getter
 @Setter
 public class GamePlayerStats {
 
-  private long id;
-  private Player player;
-  private boolean ai;
-  private Faction faction;
-  private byte color;
-  private byte team;
-  private byte startSpot;
-  private Double beforeMean;
-  private Double beforeDeviation;
-  private Double afterMean;
-  private Double afterDeviation;
-  private Byte score;
-  private OffsetDateTime scoreTime;
-  private Game game;
-
   @Id
   @Column(name = "id")
-  public long getId() {
-    return id;
-  }
+  private long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "playerId")
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @Column(name = "AI")
-  public boolean getAi() {
-    return ai;
-  }
+  private boolean ai;
 
   @Column(name = "faction")
-  public Faction getFaction() {
-    return faction;
-  }
+  private Faction faction;
 
   @Column(name = "color")
-  public byte getColor() {
-    return color;
-  }
+  private byte color;
 
   @Column(name = "team")
-  public byte getTeam() {
-    return team;
-  }
+  private byte team;
 
   @Column(name = "place")
-  public byte getStartSpot() {
-    return startSpot;
-  }
+  private byte startSpot;
 
   @Column(name = "mean")
-  public Double getBeforeMean() {
-    return beforeMean;
-  }
+  private Double beforeMean;
 
   @Column(name = "deviation")
-  public Double getBeforeDeviation() {
-    return beforeDeviation;
-  }
+  private Double beforeDeviation;
 
   @Column(name = "after_mean")
-  public Double getAfterMean() {
-    return afterMean;
-  }
+  private Double afterMean;
 
   @Column(name = "after_deviation")
-  public Double getAfterDeviation() {
-    return afterDeviation;
-  }
+  private Double afterDeviation;
 
   @Column(name = "score")
-  public Byte getScore() {
-    return score;
-  }
+  private Byte score;
 
   @Column(name = "scoreTime")
-  public OffsetDateTime getScoreTime() {
-    return scoreTime;
-  }
+  private OffsetDateTime scoreTime;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "gameId")
-  public Game getGame() {
-    return game;
-  }
+  private Game game;
 }

--- a/src/main/java/com/faforever/api/data/domain/GameReview.java
+++ b/src/main/java/com/faforever/api/data/domain/GameReview.java
@@ -5,6 +5,7 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
@@ -13,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+@Getter
 @Setter
 @Include(rootLevel = true, type = "gameReview")
 @Entity
@@ -21,12 +23,8 @@ import javax.persistence.Table;
 @DeletePermission(expression = IsEntityOwner.EXPRESSION)
 public class GameReview extends Review {
 
-  private Game game;
-
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "game_id")
   @UpdatePermission(expression = "Prefab.Role.All and Prefab.Common.UpdateOnCreate")
-  public Game getGame() {
-    return game;
-  }
+  private Game game;
 }

--- a/src/main/java/com/faforever/api/data/domain/GameReviewsSummary.java
+++ b/src/main/java/com/faforever/api/data/domain/GameReviewsSummary.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Immutable;
@@ -12,53 +13,33 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
+@Getter
 @Setter
 @Table(name = "game_reviews_summary")
 @Include(rootLevel = true, type = "gameReviewsSummary")
 @Immutable
 public class GameReviewsSummary {
-  private int id;
-  private float positive;
-  private float negative;
-  private float score;
-  private int reviews;
-  private float lowerBound;
-  private Game game;
 
   @Id
   @Column(name = "game_id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "positive")
-  public float getPositive() {
-    return positive;
-  }
+  private float positive;
 
   @Column(name = "negative")
-  public float getNegative() {
-    return negative;
-  }
+  private float negative;
 
   @Column(name = "score")
-  public float getScore() {
-    return score;
-  }
+  private float score;
 
   @Column(name = "reviews")
-  public int getReviews() {
-    return reviews;
-  }
+  private int reviews;
 
   @Column(name = "lower_bound")
-  public float getLowerBound() {
-    return lowerBound;
-  }
+  private float lowerBound;
 
   @OneToOne(mappedBy = "reviewsSummary")
   @BatchSize(size = 1000)
-  public Game getGame() {
-    return game;
-  }
+  private Game game;
 }

--- a/src/main/java/com/faforever/api/data/domain/Ladder1v1Map.java
+++ b/src/main/java/com/faforever/api/data/domain/Ladder1v1Map.java
@@ -7,6 +7,7 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Immutable;
 
@@ -22,6 +23,7 @@ import javax.persistence.Table;
 @CreatePermission(expression = HasLadder1v1Update.EXPRESSION)
 @DeletePermission(expression = HasLadder1v1Update.EXPRESSION)
 @Entity
+@Getter
 @Setter
 @Table(name = "ladder_map")
 @Include(rootLevel = true, type = "ladder1v1Map")
@@ -29,20 +31,14 @@ import javax.persistence.Table;
 @Audit(action = Action.CREATE, logStatement = "Added map `{0}` with version `{1}` to the ladder pool", logExpressions = {"${ladder1v1Map.mapVersion.map.displayName}", "${ladder1v1Map.mapVersion.version}"})
 @Audit(action = Action.DELETE, logStatement = "Removed map `{0}` with version `{1}` from the ladder pool", logExpressions = {"${ladder1v1Map.mapVersion.map.displayName}", "${ladder1v1Map.mapVersion.version}"})
 public class Ladder1v1Map {
-  private int id;
-  private MapVersion mapVersion;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @OneToOne
   @JoinColumn(name = "idmap")
   @UpdatePermission(expression = HasLadder1v1Update.EXPRESSION)
-  public MapVersion getMapVersion() {
-    return mapVersion;
-  }
+  private MapVersion mapVersion;
 }

--- a/src/main/java/com/faforever/api/data/domain/LobbyGroup.java
+++ b/src/main/java/com/faforever/api/data/domain/LobbyGroup.java
@@ -2,6 +2,7 @@ package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
@@ -17,30 +18,22 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "lobby_admin")
+@Getter
 @Setter
 @Deprecated
 @NoArgsConstructor
 @AllArgsConstructor
 @Include(type = "lobbyGroup")
 public class LobbyGroup {
-  private int userId;
-  private LegacyAccessLevel accessLevel;
-  private User user;
-
-  @Column(name = "\"group\"")
-  public LegacyAccessLevel getAccessLevel() {
-    return accessLevel;
-  }
 
   @Id
   @Column(name = "user_id")
-  public int getUserId() {
-    return userId;
-  }
+  private int userId;
+
+  @Column(name = "\"group\"")
+  private LegacyAccessLevel accessLevel;
 
   @OneToOne
   @JoinColumn(name = "user_id", insertable = false, updatable = false)
-  public User getUser() {
-    return user;
-  }
+  private User user;
 }

--- a/src/main/java/com/faforever/api/data/domain/Login.java
+++ b/src/main/java/com/faforever/api/data/domain/Login.java
@@ -5,6 +5,7 @@ import com.faforever.api.data.checks.permission.IsModerator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -19,69 +20,47 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @MappedSuperclass
+@Getter
 @Setter
 public abstract class Login extends AbstractEntity implements OwnableEntity {
 
+  @Column(name = "login")
   private String login;
+
+  @Column(name = "email")
+  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + IsModerator.EXPRESSION)
   private String email;
+
+  @Column(name = "steamid")
+  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + IsModerator.EXPRESSION)
   private String steamId;
+
+  @Column(name = "user_agent")
   private String userAgent;
+
+  @OneToMany(mappedBy = "player", fetch = FetchType.EAGER)
+  // Permission is managed by BanInfo class
+  @UpdatePermission(expression = IsModerator.EXPRESSION)
   private Set<BanInfo> bans;
+
+  @OneToMany(mappedBy = "player", fetch = FetchType.EAGER)
+  @UpdatePermission(expression = IsModerator.EXPRESSION)
   private Set<UserNote> userNotes;
+
+  @OneToOne(mappedBy = "user")
   private LobbyGroup lobbyGroup;
+
+  @Column(name = "ip")
+  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + IsModerator.EXPRESSION)
   private String recentIpAddress;
+
+  @Column(name = "last_login")
+  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + IsModerator.EXPRESSION)
   private OffsetDateTime lastLogin;
 
   public Login() {
     this.bans = new HashSet<>(0);
     this.userNotes = new HashSet<>(0);
-  }
-
-  @Column(name = "login")
-  public String getLogin() {
-    return login;
-  }
-
-  @Column(name = "email")
-  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + IsModerator.EXPRESSION)
-  public String getEmail() {
-    return email;
-  }
-
-  @Column(name = "steamid")
-  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + IsModerator.EXPRESSION)
-  public String getSteamId() {
-    return steamId;
-  }
-
-  @Column(name = "ip")
-  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + IsModerator.EXPRESSION)
-  public String getRecentIpAddress() {
-    return recentIpAddress;
-  }
-
-  @Column(name = "last_login")
-  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + IsModerator.EXPRESSION)
-  public OffsetDateTime getLastLogin() {
-    return lastLogin;
-  }
-
-  @Column(name = "user_agent")
-  public String getUserAgent() {
-    return userAgent;
-  }
-
-  @OneToMany(mappedBy = "player", fetch = FetchType.EAGER)
-  // Permission is managed by BanInfo class
-  @UpdatePermission(expression = IsModerator.EXPRESSION)
-  public Set<BanInfo> getBans() {
-    return this.bans;
-  }
-
-  @OneToMany(mappedBy = "player", fetch = FetchType.EAGER)
-  @UpdatePermission(expression = IsModerator.EXPRESSION)
-  public Set<UserNote> getUserNotes() {
-    return this.userNotes;
   }
 
   @Transient
@@ -92,11 +71,6 @@ public abstract class Login extends AbstractEntity implements OwnableEntity {
   @Transient
   public boolean isGlobalBanned() {
     return getActiveBans().stream().anyMatch(ban -> ban.getLevel() == BanLevel.GLOBAL);
-  }
-
-  @OneToOne(mappedBy = "user")
-  public LobbyGroup getLobbyGroup() {
-    return lobbyGroup;
   }
 
   @Override

--- a/src/main/java/com/faforever/api/data/domain/Map.java
+++ b/src/main/java/com/faforever/api/data/domain/Map.java
@@ -2,6 +2,7 @@ package com.faforever.api.data.domain;
 
 import com.faforever.api.data.listeners.MapChangeListener;
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Formula;
@@ -9,7 +10,6 @@ import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.JoinColumnOrFormula;
 import org.hibernate.annotations.JoinColumnsOrFormulas;
 import org.hibernate.annotations.JoinFormula;
-import org.hibernate.validator.constraints.NotEmpty;
 import org.jetbrains.annotations.Nullable;
 
 import javax.persistence.CascadeType;
@@ -26,6 +26,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.OffsetDateTime;
@@ -33,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 @Setter
 @Table(name = "map")
 @Include(rootLevel = true, type = Map.TYPE_NAME)
@@ -42,96 +44,59 @@ public class Map {
 
   public static final String TYPE_NAME = "map";
 
-  private int id;
-  private String displayName;
-  private String mapType;
-  private String battleType;
-  private OffsetDateTime updateTime;
-  private OffsetDateTime createTime;
-  private List<MapVersion> versions = new ArrayList<>();
-  private Player author;
-  private MapStatistics statistics;
-  private MapVersion latestVersion;
-  private int numberOfReviews;
-  private float averageReviewScore;
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "display_name", unique = true)
   @Size(max = 100)
   @NotNull
-  public String getDisplayName() {
-    return displayName;
-  }
+  private String displayName;
 
   @Column(name = "map_type")
   @NotNull
-  public String getMapType() {
-    return mapType;
-  }
+  private String mapType;
 
   @Column(name = "battle_type")
   @NotNull
-  public String getBattleType() {
-    return battleType;
-  }
+  private String battleType;
+
+  @Formula(value = "(SELECT MAX(map_version.update_time) FROM map_version WHERE map_version.map_id = id)")
+  private OffsetDateTime updateTime;
 
   @Column(name = "create_time")
-  public OffsetDateTime getCreateTime() {
-    return createTime;
-  }
-
-  @Column(name = "reviews")
-  public int getNumberOfReviews() {
-    return numberOfReviews;
-  }
-
-  @Column(name = "average_review_score")
-  public float getAverageReviewScore() {
-    return averageReviewScore;
-  }
+  private OffsetDateTime createTime;
 
   @OneToMany(mappedBy = "map", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
   @NotEmpty
   @Valid
   @BatchSize(size = 1000)
-  public List<MapVersion> getVersions() {
-    return versions;
-  }
+  private List<MapVersion> versions = new ArrayList<>();
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "author")
   @Nullable
   @BatchSize(size = 1000)
-  public Player getAuthor() {
-    return author;
-  }
+  private Player author;
 
   @OneToOne(mappedBy = "map")
-  public MapStatistics getStatistics() {
-    return statistics;
-  }
+  private MapStatistics statistics;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumnsOrFormulas({
-      @JoinColumnOrFormula(
-          formula = @JoinFormula(
-              value = "(SELECT map_version.id FROM map_version WHERE map_version.map_id = id ORDER BY map_version.version DESC LIMIT 1)",
-              referencedColumnName = "id")
-      )
+    @JoinColumnOrFormula(
+      formula = @JoinFormula(
+        value = "(SELECT map_version.id FROM map_version WHERE map_version.map_id = id ORDER BY map_version.version DESC LIMIT 1)",
+        referencedColumnName = "id")
+    )
   })
   @BatchSize(size = 1000)
-  public MapVersion getLatestVersion() {
-    return latestVersion;
-  }
+  private MapVersion latestVersion;
 
-  @Formula(value = "(SELECT MAX(map_version.update_time) FROM map_version WHERE map_version.map_id = id)")
-  public OffsetDateTime getUpdateTime() {
-    return updateTime;
-  }
+  @Column(name = "reviews")
+  private int numberOfReviews;
+
+  @Column(name = "average_review_score")
+  private float averageReviewScore;
 }

--- a/src/main/java/com/faforever/api/data/domain/MapStatistics.java
+++ b/src/main/java/com/faforever/api/data/domain/MapStatistics.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Immutable;
 
@@ -13,6 +14,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
+@Getter
 @Setter
 @Table(name = "map_statistics")
 @Include(rootLevel = true, type = MapStatistics.TYPE_NAME)
@@ -20,36 +22,20 @@ import javax.persistence.Table;
 public class MapStatistics {
   public static final String TYPE_NAME = "mapStatistics";
 
-  private int id;
-  private int downloads;
-  private int plays;
-  private int draws;
-  private Map map;
-
   @Id
   @Column(name = "map_id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "downloads")
-  public int getDownloads() {
-    return downloads;
-  }
+  private int downloads;
 
   @Column(name = "plays")
-  public int getPlays() {
-    return plays;
-  }
+  private int plays;
 
   @Column(name = "draws")
-  public int getDraws() {
-    return draws;
-  }
+  private int draws;
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "map_id", insertable = false, updatable = false)
-  public Map getMap() {
-    return map;
-  }
+  private Map map;
 }

--- a/src/main/java/com/faforever/api/data/domain/MapVersion.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersion.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.annotation.Audit.Action;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 
@@ -26,6 +27,7 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Entity
+@Getter
 @Setter
 @EntityListeners(MapVersionEnricher.class)
 @Table(name = "map_version")
@@ -34,122 +36,71 @@ public class MapVersion extends AbstractEntity implements OwnableEntity {
 
   public static final String TYPE_NAME = "mapVersion";
 
-  private String description;
-  private int maxPlayers;
-  private int width;
-  private int height;
-  private int version;
-  private String filename;
-  private String folderName;
-  private boolean ranked;
-  private boolean hidden;
-  private Map map;
-  private MapVersionStatistics statistics;
-  private String thumbnailUrlSmall;
-  private String thumbnailUrlLarge;
-  private String downloadUrl;
-  private List<MapVersionReview> reviews;
-  private MapVersionReviewsSummary reviewsSummary;
-  private Ladder1v1Map ladder1v1Map;
-
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION + " or " + IsModerator.EXPRESSION)
   @Column(name = "description")
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @Column(name = "max_players")
-  @NotNull
-  public int getMaxPlayers() {
-    return maxPlayers;
-  }
+  private int maxPlayers;
 
   @Column(name = "width")
   // FIXME: validation
-  public int getWidth() {
-    return width;
-  }
+  private int width;
 
   @Column(name = "height")
   // FIXME: validation
-  public int getHeight() {
-    return height;
-  }
+  private int height;
 
   @Column(name = "version")
   // FIXME: validation
-  public int getVersion() {
-    return version;
-  }
+  private int version;
 
   @Column(name = "filename")
   @NotNull
-  public String getFilename() {
-    return filename;
-  }
+  private String filename;
 
   @UpdatePermission(expression = IsModerator.EXPRESSION + " or (" + IsEntityOwner.EXPRESSION + " and " + BooleanChange.TO_FALSE_EXPRESSION + ")")
   @Audit(action = Action.UPDATE, logStatement = "Updated map version `{0}` attribute ranked to: {1}", logExpressions = {"${mapVersion.id}", "${mapVersion.ranked}"})
   @Column(name = "ranked")
-  public boolean isRanked() {
-    return ranked;
-  }
+  private boolean ranked;
 
   @UpdatePermission(expression = IsModerator.EXPRESSION + " or (" + IsEntityOwner.EXPRESSION + " and " + BooleanChange.TO_TRUE_EXPRESSION + ")")
   @Audit(action = Action.UPDATE, logStatement = "Updated map version `{0}` attribute hidden to: {1}", logExpressions = {"${mapVersion.id}", "${mapVersion.hidden}"})
   @Column(name = "hidden")
-  public boolean isHidden() {
-    return hidden;
-  }
+  private boolean hidden;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "map_id")
   @NotNull
   @BatchSize(size = 1000)
-  public Map getMap() {
-    return this.map;
-  }
+  private Map map;
 
   @OneToOne(mappedBy = "mapVersion", fetch = FetchType.EAGER)
-  public MapVersionStatistics getStatistics() {
-    return statistics;
-  }
+  private MapVersionStatistics statistics;
 
   @Transient
   @ComputedAttribute
-  public String getThumbnailUrlSmall() {
-    return thumbnailUrlSmall;
-  }
+  private String thumbnailUrlSmall;
 
   @Transient
   @ComputedAttribute
-  public String getThumbnailUrlLarge() {
-    return thumbnailUrlLarge;
-  }
+  private String thumbnailUrlLarge;
 
   @Transient
   @ComputedAttribute
-  public String getDownloadUrl() {
-    return downloadUrl;
-  }
+  private String downloadUrl;
 
   @Transient
   @ComputedAttribute
-  public String getFolderName() {
-    return folderName;
-  }
+  private String folderName;
 
   @OneToMany(mappedBy = "mapVersion")
   @UpdatePermission(expression = "Prefab.Role.All")
-  public List<MapVersionReview> getReviews() {
-    return reviews;
-  }
+  private List<MapVersionReview> reviews;
 
   @OneToOne(mappedBy = "mapVersion")
   @UpdatePermission(expression = "Prefab.Role.All")
-  public MapVersionReviewsSummary getReviewsSummary() {
-    return reviewsSummary;
-  }
+  private MapVersionReviewsSummary reviewsSummary;
 
   @Transient
   @Override

--- a/src/main/java/com/faforever/api/data/domain/MapVersionReview.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersionReview.java
@@ -5,6 +5,7 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
@@ -13,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+@Getter
 @Setter
 @Include(rootLevel = true, type = "mapVersionReview")
 @Entity
@@ -21,12 +23,8 @@ import javax.persistence.Table;
 @DeletePermission(expression = IsEntityOwner.EXPRESSION)
 public class MapVersionReview extends Review {
 
-  private MapVersion mapVersion;
-
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "map_version_id")
   @UpdatePermission(expression = "Prefab.Role.All and Prefab.Common.UpdateOnCreate")
-  public MapVersion getMapVersion() {
-    return mapVersion;
-  }
+  private MapVersion mapVersion;
 }

--- a/src/main/java/com/faforever/api/data/domain/MapVersionReviewsSummary.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersionReviewsSummary.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Immutable;
@@ -14,54 +15,34 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
+@Getter
 @Setter
 @Table(name = "map_version_reviews_summary")
 @Include(type = "mapVersionReviewsSummary")
 @Immutable
 public class MapVersionReviewsSummary {
-  private int id;
-  private float positive;
-  private float negative;
-  private float score;
-  private int reviews;
-  private float lowerBound;
-  private MapVersion mapVersion;
 
   @Id
   @Column(name = "map_version_id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "positive")
-  public float getPositive() {
-    return positive;
-  }
+  private float positive;
 
   @Column(name = "negative")
-  public float getNegative() {
-    return negative;
-  }
+  private float negative;
 
   @Column(name = "score")
-  public float getScore() {
-    return score;
-  }
+  private float score;
 
   @Column(name = "reviews")
-  public int getReviews() {
-    return reviews;
-  }
+  private int reviews;
 
   @Column(name = "lower_bound")
-  public float getLowerBound() {
-    return lowerBound;
-  }
+  private float lowerBound;
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "map_version_id", insertable = false, updatable = false)
   @BatchSize(size = 1000)
-  public MapVersion getMapVersion() {
-    return mapVersion;
-  }
+  private MapVersion mapVersion;
 }

--- a/src/main/java/com/faforever/api/data/domain/MapVersionStatistics.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersionStatistics.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Immutable;
@@ -14,42 +15,28 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
+@Getter
 @Setter
 @Table(name = "map_version_statistics")
 @Include(rootLevel = true, type = "mapVersionStatistics")
 @Immutable
 public class MapVersionStatistics {
-  private int id;
-  private int downloads;
-  private int plays;
-  private int draws;
-  private MapVersion mapVersion;
 
   @Id
   @Column(name = "map_version_id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "downloads")
-  public int getDownloads() {
-    return downloads;
-  }
+  private int downloads;
 
   @Column(name = "plays")
-  public int getPlays() {
-    return plays;
-  }
+  private int plays;
 
   @Column(name = "draws")
-  public int getDraws() {
-    return draws;
-  }
+  private int draws;
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "map_version_id", insertable = false, updatable = false)
   @BatchSize(size = 1000)
-  public MapVersion getMapVersion() {
-    return mapVersion;
-  }
+  private MapVersion mapVersion;
 }

--- a/src/main/java/com/faforever/api/data/domain/Message.java
+++ b/src/main/java/com/faforever/api/data/domain/Message.java
@@ -10,6 +10,7 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -22,6 +23,7 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "messages")
+@Getter
 @Setter
 @Include(rootLevel = true)
 @DeletePermission(expression = IsModerator.EXPRESSION)
@@ -35,36 +37,21 @@ import javax.persistence.Table;
 public class Message {
 
   public static final String TYPE_NAME = "message";
-  private Integer id;
-  private String key;
-  private String language;
-  private String region;
-  private String value;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
-  public Integer getId() {
-    return id;
-  }
+  private Integer id;
 
   @Column(name = "`key`")
-  public String getKey() {
-    return key;
-  }
+  private String key;
 
   @Column(name = "language")
-  public String getLanguage() {
-    return language;
-  }
+  private String language;
 
   @Column(name = "region")
-  public String getRegion() {
-    return region;
-  }
+  private String region;
 
   @Column(name = "value")
-  public String getValue() {
-    return value;
-  }
+  private String value;
 }

--- a/src/main/java/com/faforever/api/data/domain/Mod.java
+++ b/src/main/java/com/faforever/api/data/domain/Mod.java
@@ -1,13 +1,13 @@
 package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.JoinColumnOrFormula;
 import org.hibernate.annotations.JoinColumnsOrFormulas;
 import org.hibernate.annotations.JoinFormula;
-import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -20,6 +20,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.OffsetDateTime;
@@ -29,75 +30,47 @@ import java.util.List;
 @Table(name = "\"mod\"")
 @Include(rootLevel = true, type = Mod.TYPE_NAME)
 @Immutable
+@Getter
 @Setter
 public class Mod {
 
   public static final String TYPE_NAME = "mod";
 
-  private Integer id;
-  private String displayName;
-  private String author;
-  private OffsetDateTime createTime;
-  private OffsetDateTime updateTime;
-  private List<ModVersion> versions;
-  private ModVersion latestVersion;
-  private Player uploader;
-  private int numberOfReviews;
-  private float averageReviewScore;
-
   @Id
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  public Integer getId() {
-    return id;
-  }
+  private Integer id;
 
   @Column(name = "display_name")
   @Size(max = 100)
   @NotNull
-  public String getDisplayName() {
-    return displayName;
-  }
+  private String displayName;
 
   @Column(name = "author")
   @Size(max = 100)
   @NotNull
-  public String getAuthor() {
-    return author;
-  }
+  private String author;
 
   @Column(name = "reviews")
-  public int getNumberOfReviews() {
-    return numberOfReviews;
-  }
+  private int numberOfReviews;
 
   @Column(name = "average_review_score")
-  public float getAverageReviewScore() {
-    return averageReviewScore;
-  }
+  private float averageReviewScore;
 
   @ManyToOne
   @JoinColumn(name = "uploader")
-  public Player getUploader() {
-    return uploader;
-  }
+  private Player uploader;
 
   @Column(name = "create_time")
-  public OffsetDateTime getCreateTime() {
-    return createTime;
-  }
+  private OffsetDateTime createTime;
 
   @Formula(value = "(SELECT MAX(mod_version.update_time) FROM mod_version WHERE mod_version.mod_id = id)")
-  public OffsetDateTime getUpdateTime() {
-    return updateTime;
-  }
+  private OffsetDateTime updateTime;
 
   @OneToMany(mappedBy = "mod", cascade = CascadeType.ALL, orphanRemoval = true)
   @NotEmpty
   @Valid
-  public List<ModVersion> getVersions() {
-    return versions;
-  }
+  private List<ModVersion> versions;
 
   @ManyToOne
   @JoinColumnsOrFormulas({
@@ -107,7 +80,5 @@ public class Mod {
         referencedColumnName = "id")
     )
   })
-  public ModVersion getLatestVersion() {
-    return latestVersion;
-  }
+  private ModVersion latestVersion;
 }

--- a/src/main/java/com/faforever/api/data/domain/ModVersion.java
+++ b/src/main/java/com/faforever/api/data/domain/ModVersion.java
@@ -8,6 +8,7 @@ import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -31,120 +32,71 @@ import java.util.List;
 @Entity
 @Table(name = "mod_version")
 @Include(rootLevel = true, type = ModVersion.TYPE_NAME)
+@Getter
 @Setter
 @EntityListeners(ModVersionEnricher.class)
 public class ModVersion {
-
   public static final String TYPE_NAME = "modVersion";
-
-  private Integer id;
-  private String uid;
-  private ModType type;
-  private String description;
-  private short version;
-  private String filename;
-  private String icon;
-  private boolean ranked;
-  private boolean hidden;
-  private OffsetDateTime createTime;
-  private OffsetDateTime updateTime;
-  private Mod mod;
-  private String thumbnailUrl;
-  private String downloadUrl;
-  private List<ModVersionReview> reviews;
-  private ModVersionReviewsSummary reviewsSummary;
 
   @Id
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  public Integer getId() {
-    return id;
-  }
+  private Integer id;
 
   @Column(name = "uid")
-  public String getUid() {
-    return uid;
-  }
+  private String uid;
 
   @Column(name = "type")
   @Enumerated(EnumType.STRING)
-  public ModType getType() {
-    return type;
-  }
+  private ModType type;
 
   @Column(name = "description")
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @Column(name = "version")
-  public short getVersion() {
-    return version;
-  }
+  private short version;
 
   @Column(name = "filename")
-  public String getFilename() {
-    return filename;
-  }
+  private String filename;
 
   @Column(name = "icon")
   // Excluded since I see no reason why this is even stored in the database.
   @Exclude
-  public String getIcon() {
-    return icon;
-  }
+  private String icon;
 
   @UpdatePermission(expression = IsModerator.EXPRESSION)
   @Audit(action = Action.UPDATE, logStatement = "Updated mod version `{0}` attribute ranked to: {1}", logExpressions = {"${modVersion.id}", "${modVersion.ranked}"})
   @Column(name = "ranked")
-  public boolean isRanked() {
-    return ranked;
-  }
+  private boolean ranked;
 
   @UpdatePermission(expression = IsModerator.EXPRESSION)
   @Audit(action = Action.UPDATE, logStatement = "Updated mod version `{0}` attribute hidden to: {1}", logExpressions = {"${modVersion.id}", "${modVersion.hidden}"})
   @Column(name = "hidden")
-  public boolean isHidden() {
-    return hidden;
-  }
+  private boolean hidden;
 
   @Column(name = "create_time")
-  public OffsetDateTime getCreateTime() {
-    return createTime;
-  }
+  private OffsetDateTime createTime;
 
   @Column(name = "update_time")
-  public OffsetDateTime getUpdateTime() {
-    return updateTime;
-  }
+  private OffsetDateTime updateTime;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "mod_id")
-  public Mod getMod() {
-    return mod;
-  }
+  private Mod mod;
 
   @Transient
   @ComputedAttribute
-  public String getThumbnailUrl() {
-    return thumbnailUrl;
-  }
+  private String thumbnailUrl;
 
   @Transient
   @ComputedAttribute
-  public String getDownloadUrl() {
-    return downloadUrl;
-  }
+  private String downloadUrl;
 
   @OneToMany(mappedBy = "modVersion")
   @UpdatePermission(expression = "Prefab.Role.All")
-  public List<ModVersionReview> getReviews() {
-    return reviews;
-  }
+  private List<ModVersionReview> reviews;
 
   @OneToOne(mappedBy = "modVersion")
   @UpdatePermission(expression = "Prefab.Role.All")
-  public ModVersionReviewsSummary getReviewsSummary() {
-    return reviewsSummary;
-  }
+  private ModVersionReviewsSummary reviewsSummary;
 }

--- a/src/main/java/com/faforever/api/data/domain/ModVersionReview.java
+++ b/src/main/java/com/faforever/api/data/domain/ModVersionReview.java
@@ -5,6 +5,7 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
@@ -13,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+@Getter
 @Setter
 @Include(rootLevel = true, type = "modVersionReview")
 @Entity
@@ -21,12 +23,8 @@ import javax.persistence.Table;
 @DeletePermission(expression = IsEntityOwner.EXPRESSION)
 public class ModVersionReview extends Review {
 
-  private ModVersion modVersion;
-
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "mod_version_id")
   @UpdatePermission(expression = "Prefab.Role.All and Prefab.Common.UpdateOnCreate")
-  public ModVersion getModVersion() {
-    return modVersion;
-  }
+  private ModVersion modVersion;
 }

--- a/src/main/java/com/faforever/api/data/domain/ModVersionReviewsSummary.java
+++ b/src/main/java/com/faforever/api/data/domain/ModVersionReviewsSummary.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Immutable;
@@ -14,54 +15,34 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
+@Getter
 @Setter
 @Table(name = "mod_version_reviews_summary")
 @Include(type = "modVersionReviewsSummary")
 @Immutable
 public class ModVersionReviewsSummary {
-  private int id;
-  private float positive;
-  private float negative;
-  private float score;
-  private int reviews;
-  private float lowerBound;
-  private ModVersion modVersion;
 
   @Id
   @Column(name = "mod_version_id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "positive")
-  public float getPositive() {
-    return positive;
-  }
+  private float positive;
 
   @Column(name = "negative")
-  public float getNegative() {
-    return negative;
-  }
+  private float negative;
 
   @Column(name = "score")
-  public float getScore() {
-    return score;
-  }
+  private float score;
 
   @Column(name = "reviews")
-  public int getReviews() {
-    return reviews;
-  }
+  private int reviews;
 
   @Column(name = "lower_bound")
-  public float getLowerBound() {
-    return lowerBound;
-  }
+  private float lowerBound;
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "mod_version_id", insertable = false, updatable = false)
   @BatchSize(size = 1000)
-  public ModVersion getModVersion() {
-    return modVersion;
-  }
+  private ModVersion modVersion;
 }

--- a/src/main/java/com/faforever/api/data/domain/ModerationReport.java
+++ b/src/main/java/com/faforever/api/data/domain/ModerationReport.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.annotation.OnUpdatePreSecurity;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.core.RequestScope;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -40,6 +41,7 @@ import java.util.Set;
 
 @Entity
 @Table(name = "moderation_report")
+@Getter
 @Setter
 @ToString(exclude = {"reportedUsers", "bans"})
 @Include(rootLevel = true, type = ModerationReport.TYPE_NAME)
@@ -50,76 +52,50 @@ import java.util.Set;
 @Audit(action = Action.UPDATE, logStatement = "Moderation report `{0}` has been updated", logExpressions = "${moderationReport}")
 public class ModerationReport extends AbstractEntity implements OwnableEntity {
   public static final String TYPE_NAME = "moderationReport";
-  private ModerationReportStatus reportStatus;
-  private Player reporter;
-  private String reportDescription;
-  private String gameIncidentTimecode;
-  private Game game;
-  private String moderatorNotice;
-  private String moderatorPrivateNote;
-  private Player lastModerator;
-  private Set<Player> reportedUsers;
-  private Collection<BanInfo> bans;
 
   @NotNull
   @Column(name = "report_status")
   @Enumerated(EnumType.STRING)
   @CreatePermission(expression = Prefab.NONE)
   @UpdatePermission(expression = IsModerator.EXPRESSION)
-  public ModerationReportStatus getReportStatus() {
-    return reportStatus;
-  }
+  private ModerationReportStatus reportStatus;
 
   @NotNull
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "reporter_id", referencedColumnName = "id")
   @CreatePermission(expression = Prefab.ALL_AND_UPDATE_ON_CREATE)
-  public Player getReporter() {
-    return reporter;
-  }
+  private Player reporter;
 
   @NotNull
   @Column(name = "report_description")
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION + " and " + IsInAwaitingState.EXPRESSION)
-  public String getReportDescription() {
-    return reportDescription;
-  }
+  private String reportDescription;
 
   @Column(name = "game_incident_timecode")
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION + " and " + IsInAwaitingState.EXPRESSION)
-  public String getGameIncidentTimecode() {
-    return gameIncidentTimecode;
-  }
+  private String gameIncidentTimecode;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "game_id", referencedColumnName = "id")
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION + " and " + IsInAwaitingState.EXPRESSION)
-  public Game getGame() {
-    return game;
-  }
+  private Game game;
 
   @Column(name = "moderator_notice")
   @CreatePermission(expression = Prefab.NONE)
   @UpdatePermission(expression = IsModerator.EXPRESSION)
-  public String getModeratorNotice() {
-    return moderatorNotice;
-  }
+  private String moderatorNotice;
 
   @Column(name = "moderator_private_note")
   @ReadPermission(expression = IsModerator.EXPRESSION)
   @CreatePermission(expression = Prefab.NONE)
   @UpdatePermission(expression = IsModerator.EXPRESSION)
-  public String getModeratorPrivateNote() {
-    return moderatorPrivateNote;
-  }
+  private String moderatorPrivateNote;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "last_moderator", referencedColumnName = "id")
   @CreatePermission(expression = Prefab.NONE)
   @UpdatePermission(expression = IsModerator.EXPRESSION)
-  public Player getLastModerator() {
-    return lastModerator;
-  }
+  private Player lastModerator;
 
   @Size(min = 1)
   @NotNull
@@ -133,17 +109,13 @@ public class ModerationReport extends AbstractEntity implements OwnableEntity {
     inverseJoinColumns = @JoinColumn(name = "player_id")
   )
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION + " and " + IsInAwaitingState.EXPRESSION + " or " + Prefab.UPDATE_ON_CREATE)
-  public Set<Player> getReportedUsers() {
-    return reportedUsers;
-  }
+  private Set<Player> reportedUsers;
 
   @OneToMany(mappedBy = "moderationReport")
   @ReadPermission(expression = IsModerator.EXPRESSION)
   // Permission is managed by BanInfo class
   @UpdatePermission(expression = Prefab.ALL)
-  public Collection<BanInfo> getBans() {
-    return bans;
-  }
+  private Collection<BanInfo> bans;
 
   @Override
   @Transient

--- a/src/main/java/com/faforever/api/data/domain/NameRecord.java
+++ b/src/main/java/com/faforever/api/data/domain/NameRecord.java
@@ -3,6 +3,7 @@ package com.faforever.api.data.domain;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -20,34 +21,23 @@ import java.time.OffsetDateTime;
 @Include(rootLevel = true, type = "nameRecord")
 @DeletePermission(expression = "Prefab.Role.None")
 @UpdatePermission(expression = "Prefab.Role.None")
+@Getter
 @Setter
 public class NameRecord {
-  private int id;
-  private OffsetDateTime changeTime;
-  private Player player;
-  private String name;
 
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "change_time")
-  public OffsetDateTime getChangeTime() {
-    return changeTime;
-  }
+  private OffsetDateTime changeTime;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   @NotNull
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @Column(name = "previous_name")
   @NotNull
-  public String getName() {
-    return name;
-  }
+  private String name;
 }

--- a/src/main/java/com/faforever/api/data/domain/PlayerAchievement.java
+++ b/src/main/java/com/faforever/api/data/domain/PlayerAchievement.java
@@ -2,6 +2,7 @@ package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -16,41 +17,26 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "player_achievements")
 @Include(rootLevel = true, type = "playerAchievement")
+@Getter
 @Setter
 public class PlayerAchievement extends AbstractEntity {
 
-  private Integer currentSteps;
-  private AchievementState state;
-  private Player player;
-  private int playerId;
-  private Achievement achievement;
-
   @Column(name = "current_steps")
-  public Integer getCurrentSteps() {
-    return currentSteps;
-  }
+  private Integer currentSteps;
 
   @Column(name = "state")
   @Enumerated(EnumType.STRING)
-  public AchievementState getState() {
-    return state;
-  }
+  private AchievementState state;
 
   @Exclude
   @Column(name = "player_id")
-  public int getPlayerId() {
-    return playerId;
-  }
+  private int playerId;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "player_id", insertable = false, updatable = false)
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "achievement_id")
-  public Achievement getAchievement() {
-    return achievement;
-  }
+  private Achievement achievement;
 }

--- a/src/main/java/com/faforever/api/data/domain/PlayerDivisionInfo.java
+++ b/src/main/java/com/faforever/api/data/domain/PlayerDivisionInfo.java
@@ -27,52 +27,30 @@ import javax.persistence.Table;
 @ToString(of = {"id", "league", "player", "score"})
 public class PlayerDivisionInfo {
 
-  private int id;
-  private int season;
-  private Player player;
-  private int league;
-  private float score;
-  private int games;
-  private Division division;
-
   @Id
   @Column(name = "id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "season")
-  public int getSeason() {
-    return season;
-  }
+  private int season;
 
   @ManyToOne
   @JoinColumn(name = "user_id")
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @Column(name = "league")
-  public int getLeague() {
-    return league;
-  }
+  private int league;
 
   @Column(name = "score")
-  public float getScore() {
-    return score;
-  }
+  private float score;
 
   @Column(name = "games")
-  public int getGames() {
-    return games;
-  }
+  private int games;
 
   @ManyToOne
   @JoinColumnsOrFormulas({
     @JoinColumnOrFormula(formula = @JoinFormula(value = "(SELECT d.id from ladder_division d WHERE d.league = league AND score <= d.threshold ORDER BY d.threshold DESC LIMIT 1)", referencedColumnName = "id")),
   })
-  public Division getDivision() {
-    return division;
-  }
+  private Division division;
 }

--- a/src/main/java/com/faforever/api/data/domain/PlayerEvent.java
+++ b/src/main/java/com/faforever/api/data/domain/PlayerEvent.java
@@ -2,6 +2,7 @@ package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -15,34 +16,22 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "player_events")
 @Include(rootLevel = true, type = "playerEvent")
+@Getter
 @Setter
 public class PlayerEvent extends AbstractEntity {
 
+  @Exclude
+  @Column(name = "player_id")
   private int playerId;
-  private Player player;
-  private Event event;
-  private int currentCount;
 
   @OneToOne
   @JoinColumn(name = "player_id", insertable = false, updatable = false)
-  public Player getPlayer() {
-    return player;
-  }
-
-  @Exclude
-  @Column(name = "player_id")
-  public int getPlayerId() {
-    return playerId;
-  }
+  private Player player;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "event_id", updatable = false)
-  public Event getEvent() {
-    return event;
-  }
+  private Event event;
 
   @Column(name = "count")
-  public int getCurrentCount() {
-    return currentCount;
-  }
+  private int currentCount;
 }

--- a/src/main/java/com/faforever/api/data/domain/Rating.java
+++ b/src/main/java/com/faforever/api/data/domain/Rating.java
@@ -1,6 +1,7 @@
 package com.faforever.api.data.domain;
 
 
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.GenerationTime;
@@ -16,40 +17,25 @@ import javax.persistence.OneToOne;
 
 @MappedSuperclass
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Getter
 @Setter
 public abstract class Rating {
 
-  private int id;
-  private Double mean;
-  private Double deviation;
-  private Player player;
-  private double rating;
-
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "mean")
-  public Double getMean() {
-    return mean;
-  }
+  private Double mean;
 
   @Column(name = "deviation")
-  public Double getDeviation() {
-    return deviation;
-  }
+  private Double deviation;
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "id", updatable = false, insertable = false)
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @Column(name = "rating", updatable = false)
   @Generated(GenerationTime.ALWAYS)
-  public double getRating() {
-    return rating;
-  }
+  private double rating;
 }

--- a/src/main/java/com/faforever/api/data/domain/Review.java
+++ b/src/main/java/com/faforever/api/data/domain/Review.java
@@ -2,6 +2,7 @@ package com.faforever.api.data.domain;
 
 import com.faforever.api.data.checks.IsEntityOwner;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -13,33 +14,25 @@ import javax.persistence.Transient;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 
+@Getter
 @Setter
 @MappedSuperclass
 public class Review extends AbstractEntity implements OwnableEntity {
-  private String text;
-  private Byte score;
-  private Player player;
 
   @Column(name = "text")
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION)
-  public String getText() {
-    return text;
-  }
+  private String text;
 
   @Column(name = "score")
   @DecimalMin("1")
   @DecimalMax("5")
   @UpdatePermission(expression = IsEntityOwner.EXPRESSION)
-  public Byte getScore() {
-    return score;
-  }
+  private Byte score;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   @UpdatePermission(expression = "Prefab.Role.All and Prefab.Common.UpdateOnCreate")
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @Override
   @Transient

--- a/src/main/java/com/faforever/api/data/domain/Teamkill.java
+++ b/src/main/java/com/faforever/api/data/domain/Teamkill.java
@@ -3,6 +3,7 @@ package com.faforever.api.data.domain;
 import com.faforever.api.data.checks.permission.IsModerator;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Immutable;
 
@@ -17,6 +18,7 @@ import javax.persistence.Table;
 import java.time.OffsetDateTime;
 
 @Entity
+@Getter
 @Setter
 @Table(name = "teamkills")
 @Include(rootLevel = true, type = Teamkill.TYPE_NAME)
@@ -25,45 +27,26 @@ import java.time.OffsetDateTime;
 public class Teamkill {
   public static final String TYPE_NAME = "teamkill";
 
-  private int id;
-  private Player teamkiller;
-  private Player victim;
-  private Game game;
-  private long gameTime;
-  private OffsetDateTime reportedAt;
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @ManyToOne
   @JoinColumn(name = "teamkiller")
-  public Player getTeamkiller() {
-    return teamkiller;
-  }
+  private Player teamkiller;
 
   @ManyToOne
   @JoinColumn(name = "victim")
-  public Player getVictim() {
-    return victim;
-  }
+  private Player victim;
 
   @ManyToOne
   @JoinColumn(name = "game_id")
-  public Game getGame() {
-    return game;
-  }
+  private Game game;
 
   @Column(name = "gametime")
-  public long getGameTime() {
-    return gameTime;
-  }
+  private long gameTime;
 
   @Column(name = "reported_at")
-  public OffsetDateTime getReportedAt() {
-    return reportedAt;
-  }
+  private OffsetDateTime reportedAt;
 }

--- a/src/main/java/com/faforever/api/data/domain/Tutorial.java
+++ b/src/main/java/com/faforever/api/data/domain/Tutorial.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,6 +26,7 @@ import javax.validation.constraints.NotNull;
 
 @Entity
 @Table(name = "tutorial")
+@Getter
 @Setter
 @Include(rootLevel = true, type = Tutorial.TYPE_NAME)
 @DeletePermission(expression = IsModerator.EXPRESSION)
@@ -37,83 +39,50 @@ import javax.validation.constraints.NotNull;
 @Type(Tutorial.TYPE_NAME)
 public class Tutorial extends AbstractEntity {
   public static final String TYPE_NAME = "tutorial";
-  private String descriptionKey;
+
+  @Transient
+  @ComputedAttribute
   private String description;
-  private String titleKey;
+
+  @Transient
+  @ComputedAttribute
   private String title;
-  private TutorialCategory category;
-  private String image;
-  private String imageUrl;
-  private Integer ordinal;
-  private Boolean launchable;
-  private MapVersion mapVersion;
-  private String technicalName;
-
-  @Transient
-  @ComputedAttribute
-  public String getDescription() {
-    return description;
-  }
-
-  @Transient
-  @ComputedAttribute
-  public String getTitle() {
-    return title;
-  }
 
   @ManyToOne()
   @JoinColumn(name = "category")
   @Nullable
-  public TutorialCategory getCategory() {
-    return category;
-  }
+  private TutorialCategory category;
 
   @NotNull
   @Column(name = "ordinal")
-  public Integer getOrdinal() {
-    return ordinal;
-  }
+  private Integer ordinal;
 
   @NotNull
   @Column(name = "launchable")
-  public Boolean getLaunchable() {
-    return launchable;
-  }
+  private Boolean launchable;
 
   @ManyToOne
   @Nullable
   @JoinColumn(name = "map_version_id")
-  public MapVersion getMapVersion() {
-    return mapVersion;
-  }
+  private MapVersion mapVersion;
 
   @Column(name = "description_key")
-  public String getDescriptionKey() {
-    return descriptionKey;
-  }
+  private String descriptionKey;
 
   @Column(name = "title_key")
   @NotNull
-  public String getTitleKey() {
-    return titleKey;
-  }
+  private String titleKey;
 
   @Column(name = "image")
   @Nullable
-  public String getImage() {
-    return image;
-  }
+  private String image;
 
   @ComputedAttribute
   @Transient
   @Nullable
-  public String getImageUrl() {
-    return imageUrl;
-  }
+  private String imageUrl;
 
   @Column(name = "technical_name")
   @NotNull
-  public String getTechnicalName() {
-    return technicalName;
-  }
+  private String technicalName;
 }

--- a/src/main/java/com/faforever/api/data/domain/TutorialCategory.java
+++ b/src/main/java/com/faforever/api/data/domain/TutorialCategory.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.CascadeType;
@@ -29,6 +30,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "tutorial_category")
+@Getter
 @Setter
 @Include(rootLevel = true, type = TutorialCategory.TYPE_NAME)
 @DeletePermission(expression = IsModerator.EXPRESSION)
@@ -42,32 +44,19 @@ import java.util.List;
 public class TutorialCategory {
   public static final String TYPE_NAME = "tutorialCategory";
 
-  private int id;
-  private String categoryKey;
-  private String category;
-  private List<Tutorial> tutorials;
-
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "category_key")
   @NotNull
-  public String getCategoryKey() {
-    return categoryKey;
-  }
+  private String categoryKey;
 
   @Transient
   @ComputedAttribute
-  public String getCategory() {
-    return category;
-  }
+  private String category;
 
   @OneToMany(mappedBy = "category", cascade = CascadeType.REMOVE)
-  public List<Tutorial> getTutorials() {
-    return tutorials;
-  }
+  private List<Tutorial> tutorials;
 }

--- a/src/main/java/com/faforever/api/data/domain/User.java
+++ b/src/main/java/com/faforever/api/data/domain/User.java
@@ -2,6 +2,7 @@ package com.faforever.api.data.domain;
 
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -10,14 +11,11 @@ import javax.persistence.Table;
 
 @Entity
 @Table(name = "login")
+@Getter
 @Setter
 @Include(type = "user")
 public class User extends Login {
-  private String password;
-
   @Column(name = "password")
   @ReadPermission(expression = "Prefab.Role.None")
-  public String getPassword() {
-    return password;
-  }
+  private String password;
 }

--- a/src/main/java/com/faforever/api/data/domain/UserNote.java
+++ b/src/main/java/com/faforever/api/data/domain/UserNote.java
@@ -8,6 +8,7 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -26,37 +27,26 @@ import javax.validation.constraints.NotNull;
 @UpdatePermission(expression = IsModerator.EXPRESSION)
 @DeletePermission(expression = "Prefab.Role.None")
 @Audit(action = Action.CREATE, logStatement = "Note `{0}` for user `{1}` added (watched=`{2}`) with text: {3}", logExpressions = {"${userNote.id}", "${userNote.player.id}", "${userNote.watched}", "${userNote.note}"})
+@Getter
 @Setter
 public class UserNote extends AbstractEntity {
-  private Player player;
-  private Player author;
-  private boolean watched;
-  private String note;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   @NotNull
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "author")
   @NotNull
-  public Player getAuthor() {
-    return author;
-  }
+  private Player author;
 
   @Audit(action = Action.UPDATE, logStatement = "Note `{0}` for user `{1}` update with watched: {2}`", logExpressions = {"${userNote.id}", "${userNote.player.id}", "${userNote.watched}"})
   @Column(name = "watched")
-  public boolean isWatched() {
-    return watched;
-  }
+  private boolean watched;
 
   @Audit(action = Action.UPDATE, logStatement = "Note `{0}` for user `{1}` updated with text: {2}", logExpressions = {"${userNote.id}", "${userNote.player.id}", "${userNote.note}"})
   @Column(name = "note")
   @NotNull
-  public String getNote() {
-    return note;
-  }
+  private String note;
 }

--- a/src/main/java/com/faforever/api/data/domain/Vote.java
+++ b/src/main/java/com/faforever/api/data/domain/Vote.java
@@ -5,6 +5,7 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.CascadeType;
@@ -23,30 +24,21 @@ import java.util.Set;
 @ReadPermission(expression = IsEntityOwner.EXPRESSION)
 @UpdatePermission(expression = "Prefab.Role.None")
 @EqualsAndHashCode(of = {"player", "votingSubject"}, callSuper = false)
+@Getter
 @Setter
 public class Vote extends AbstractEntity implements OwnableEntity {
   public static final String TYPE_NAME = "vote";
 
-  private Player player;
-  private VotingSubject votingSubject;
-  private Set<VotingAnswer> votingAnswers;
-
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "player_id")
-  public Player getPlayer() {
-    return player;
-  }
+  private Player player;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "voting_subject_id")
-  public VotingSubject getVotingSubject() {
-    return votingSubject;
-  }
+  private VotingSubject votingSubject;
 
   @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, orphanRemoval = true)
-  public Set<VotingAnswer> getVotingAnswers() {
-    return votingAnswers;
-  }
+  private Set<VotingAnswer> votingAnswers;
 
   @Transient
   @Override

--- a/src/main/java/com/faforever/api/data/domain/VotingAnswer.java
+++ b/src/main/java/com/faforever/api/data/domain/VotingAnswer.java
@@ -5,6 +5,7 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -21,30 +22,21 @@ import javax.persistence.Transient;
 @ReadPermission(expression = IsEntityOwner.EXPRESSION)
 @UpdatePermission(expression = "Prefab.Role.None")
 @EqualsAndHashCode(of = {"vote", "votingChoice"}, callSuper = false)
+@Getter
 @Setter
 public class VotingAnswer extends AbstractEntity implements OwnableEntity {
   public static final String TYPE_NAME = "votingAnswer";
 
-  private Vote vote;
-  private Integer alternativeOrdinal;
-  private VotingChoice votingChoice;
-
   @Column(name = "alternative_ordinal")
-  public Integer getAlternativeOrdinal() {
-    return alternativeOrdinal;
-  }
+  private Integer alternativeOrdinal;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "vote_id")
-  public Vote getVote() {
-    return vote;
-  }
+  private Vote vote;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "voting_choice_id")
-  public VotingChoice getVotingChoice() {
-    return votingChoice;
-  }
+  private VotingChoice votingChoice;
 
   @Transient
   @Override

--- a/src/main/java/com/faforever/api/data/domain/VotingChoice.java
+++ b/src/main/java/com/faforever/api/data/domain/VotingChoice.java
@@ -13,6 +13,7 @@ import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.CascadeType;
@@ -37,66 +38,42 @@ import java.util.Set;
 @Audit(action = Action.DELETE, logStatement = "Deleted voting choice with id: {0} ", logExpressions = {"${votingChoice.id}"})
 @Audit(action = Action.UPDATE, logStatement = "Updated voting choice with id: {0} ", logExpressions = {"${votingChoice.id}"})
 @Include(rootLevel = true, type = VotingChoice.TYPE_NAME)
+@Getter
 @Setter
 @EntityListeners(VotingChoiceEnricher.class)
 public class VotingChoice extends AbstractEntity {
   public static final String TYPE_NAME = "votingChoice";
 
-  private String choiceTextKey;
-  private String choiceText;
-  private String descriptionKey;
-  private String description;
-  private Integer numberOfAnswers;
-  private Integer ordinal;
-  private VotingQuestion votingQuestion;
-  private Set<VotingAnswer> votingAnswers;
-
   @Column(name = "choice_text_key")
   @NotNull
-  public String getChoiceTextKey() {
-    return choiceTextKey;
-  }
+  private String choiceTextKey;
 
   @ComputedAttribute
   @Transient
-  public String getChoiceText() {
-    return choiceText;
-  }
+  private String choiceText;
 
   @Column(name = "description_key")
-  public String getDescriptionKey() {
-    return descriptionKey;
-  }
+  private String descriptionKey;
 
   @ComputedAttribute
   @Transient
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @Column(name = "ordinal")
   @NotNull
-  public Integer getOrdinal() {
-    return ordinal;
-  }
+  private Integer ordinal;
 
   @Transient
   @ComputedAttribute
-  public Integer getNumberOfAnswers() {
-    return numberOfAnswers;
-  }
+  private Integer numberOfAnswers;
 
   @JsonBackReference
   @JoinColumn(name = "voting_question_id")
   @ManyToOne()
-  public VotingQuestion getVotingQuestion() {
-    return votingQuestion;
-  }
+  private VotingQuestion votingQuestion;
 
   @JsonIgnore
   @Exclude
   @OneToMany(mappedBy = "votingChoice", cascade = CascadeType.ALL, orphanRemoval = true)
-  public Set<VotingAnswer> getVotingAnswers() {
-    return votingAnswers;
-  }
+  private Set<VotingAnswer> votingAnswers;
 }

--- a/src/main/java/com/faforever/api/data/domain/VotingQuestion.java
+++ b/src/main/java/com/faforever/api/data/domain/VotingQuestion.java
@@ -12,6 +12,8 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.CascadeType;
@@ -40,93 +42,63 @@ import java.util.Set;
 @Audit(action = Action.DELETE, logStatement = "Deleted voting question with id:{0}", logExpressions = {"${votingQuestion.id}"})
 @Audit(action = Action.UPDATE, logStatement = "Updated voting question with id:{0}", logExpressions = {"${votingQuestion.id}"})
 @Include(rootLevel = true, type = VotingQuestion.TYPE_NAME)
+@Getter
 @Setter
 @EntityListeners(VotingQuestionEnricher.class)
 public class VotingQuestion extends AbstractEntity {
   public static final String TYPE_NAME = "votingQuestion";
 
-  private Integer numberOfAnswers;
-  private String question;
-  private String description;
-  private String questionKey;
-  private String descriptionKey;
-  private Integer maxAnswers;
-  private Integer ordinal;
-  private Boolean alternativeQuestion;
-  private VotingSubject votingSubject;
-  private List<VotingChoice> winners;
-  private Set<VotingChoice> votingChoices;
-
+  @Getter(AccessLevel.NONE) // for type Boolean Lombok generates get* method, not is*
   @UpdatePermission(expression = "Prefab.Common.UpdateOnCreate")
   @Column(name = "alternative_voting")
-  public Boolean isAlternativeQuestion() {
-    return alternativeQuestion;
-  }
+  private Boolean alternativeQuestion;
 
   @Column(name = "ordinal")
   @UpdatePermission(expression = IsModerator.EXPRESSION)
-  public Integer getOrdinal() {
-    return ordinal;
-  }
+  private Integer ordinal;
 
-  /**
-   * Is evaluated when voting ended and revealVote is set to true
-   */
+  // Evaluated when voting has ended and revealVote is set to true
   @UpdatePermission(expression = "Prefab.Role.None")
   @JoinTable(name = "winner_for_voting_question",
     joinColumns = {@JoinColumn(name = "voting_question_id")},
     inverseJoinColumns = {@JoinColumn(name = "voting_choice_id")}
   )
   @ManyToMany
-  public List<VotingChoice> getWinners() {
-    return winners;
-  }
+  private List<VotingChoice> winners;
 
   @ComputedAttribute
   @Transient
-  public String getQuestion() {
-    return question;
-  }
+  private String question;
 
   @ComputedAttribute
   @Transient
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @JsonBackReference
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "voting_subject_id")
-  public VotingSubject getVotingSubject() {
-    return votingSubject;
-  }
+  private VotingSubject votingSubject;
 
   @NotNull
   @Column(name = "question_key", nullable = false)
-  public String getQuestionKey() {
-    return questionKey;
-  }
+  private String questionKey;
 
   @Column(name = "description_key")
-  public String getDescriptionKey() {
-    return descriptionKey;
-  }
+  private String descriptionKey;
 
   @UpdatePermission(expression = "Prefab.Common.UpdateOnCreate")
   @Column(name = "max_answers")
-  public Integer getMaxAnswers() {
-    return maxAnswers;
-  }
+  private Integer maxAnswers;
 
   @Transient
   @ComputedAttribute
-  public Integer getNumberOfAnswers() {
-    return numberOfAnswers;
-  }
+  private Integer numberOfAnswers;
 
   @JsonManagedReference
   @OneToMany(mappedBy = "votingQuestion", cascade = CascadeType.ALL, orphanRemoval = true)
-  public Set<VotingChoice> getVotingChoices() {
-    return votingChoices;
+  private Set<VotingChoice> votingChoices;
+
+  public Boolean isAlternativeQuestion() {
+    return alternativeQuestion;
   }
 }

--- a/src/main/java/com/faforever/api/data/domain/VotingSubject.java
+++ b/src/main/java/com/faforever/api/data/domain/VotingSubject.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.CascadeType;
@@ -38,94 +39,58 @@ import java.util.Set;
 @Audit(action = Action.CREATE, logStatement = "Created voting subject with id: {0}", logExpressions = {"${votingSubject.id}"})
 @Audit(action = Action.DELETE, logStatement = "Deleted voting subject with id: {0}", logExpressions = {"${votingSubject.id}"})
 @Audit(action = Action.UPDATE, logStatement = "Updated voting subject with id: {0}", logExpressions = {"${votingSubject.id}"})
+@Getter
 @Setter
 @EntityListeners(VotingSubjectEnricher.class)
 @VotingSubjectRevealWinnerCheck
 public class VotingSubject extends AbstractEntity {
   public static final String TYPE_NAME = "votingSubject";
 
-  private String subjectKey;
-  private String subject;
-  private int numberOfVotes;
-  private String topicUrl;
-  private OffsetDateTime beginOfVoteTime;
-  private OffsetDateTime endOfVoteTime;
-  private int minGamesToVote;
-  private String descriptionKey;
-  private String description;
-  private Boolean revealWinner;
-  private Set<Vote> votes;
-  private Set<VotingQuestion> votingQuestions;
-
   @Column(name = "subject_key")
   @NotNull
-  public String getSubjectKey() {
-    return subjectKey;
-  }
+  private String subjectKey;
 
   @ComputedAttribute
   @Transient
-  public String getSubject() {
-    return subject;
-  }
+  private String subject;
 
   @Column(name = "description_key")
-  public String getDescriptionKey() {
-    return descriptionKey;
-  }
+  private String descriptionKey;
 
   @Transient
   @ComputedAttribute
-  public int getNumberOfVotes() {
-    return numberOfVotes;
-  }
+  private int numberOfVotes;
 
   @UpdatePermission(expression = "Prefab.Common.UpdateOnCreate")
   @NotNull
   @Column(name = "begin_of_vote_time")
-  public OffsetDateTime getBeginOfVoteTime() {
-    return beginOfVoteTime;
-  }
+  private OffsetDateTime beginOfVoteTime;
 
   @UpdatePermission(expression = "Prefab.Common.UpdateOnCreate")
   @NotNull
   @Column(name = "end_of_vote_time")
-  public OffsetDateTime getEndOfVoteTime() {
-    return endOfVoteTime;
-  }
+  private OffsetDateTime endOfVoteTime;
 
   @DecimalMin("0")
   @Column(name = "min_games_to_vote")
-  public int getMinGamesToVote() {
-    return minGamesToVote;
-  }
+  private int minGamesToVote;
 
   @ComputedAttribute
   @Transient
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @Column(name = "topic_url")
-  public String getTopicUrl() {
-    return topicUrl;
-  }
+  private String topicUrl;
 
   @Column(name = "reveal_winner")
-  public Boolean getRevealWinner() {
-    return revealWinner;
-  }
+  private Boolean revealWinner;
 
   @JsonIgnore
   @Exclude
   @OneToMany(mappedBy = "votingSubject", cascade = CascadeType.ALL, orphanRemoval = true)
-  public Set<Vote> getVotes() {
-    return votes;
-  }
+  private Set<Vote> votes;
 
   @JsonManagedReference
   @OneToMany(mappedBy = "votingSubject", cascade = CascadeType.ALL, orphanRemoval = true)
-  public Set<VotingQuestion> getVotingQuestions() {
-    return votingQuestions;
-  }
+  private Set<VotingQuestion> votingQuestions;
 }

--- a/src/main/java/com/faforever/api/db/SchemaVersion.java
+++ b/src/main/java/com/faforever/api/db/SchemaVersion.java
@@ -1,5 +1,6 @@
 package com.faforever.api.db;
 
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Basic;
@@ -11,77 +12,47 @@ import java.sql.Timestamp;
 
 @Entity
 @Table(name = "schema_version")
+@Getter
 @Setter
 public class SchemaVersion {
 
-  private Integer installedRank;
-  private String version;
-  private String description;
-  private String type;
-  private String script;
-  private Integer checksum;
-  private String installedBy;
-  private Timestamp installedOn;
-  private Integer executionTime;
-  private boolean success;
-
   @Id
   @Column(name = "installed_rank")
-  public Integer getInstalledRank() {
-    return installedRank;
-  }
+  private Integer installedRank;
 
   @Basic
   @Column(name = "version")
-  public String getVersion() {
-    return version;
-  }
+  private String version;
 
   @Basic
   @Column(name = "description")
-  public String getDescription() {
-    return description;
-  }
+  private String description;
 
   @Basic
   @Column(name = "type")
-  public String getType() {
-    return type;
-  }
+  private String type;
 
   @Basic
   @Column(name = "script")
-  public String getScript() {
-    return script;
-  }
+  private String script;
 
   @Basic
   @Column(name = "checksum")
-  public Integer getChecksum() {
-    return checksum;
-  }
+  private Integer checksum;
 
   @Basic
   @Column(name = "installed_by")
-  public String getInstalledBy() {
-    return installedBy;
-  }
+  private String installedBy;
 
   @Basic
   @Column(name = "installed_on")
-  public Timestamp getInstalledOn() {
-    return installedOn;
-  }
+  private Timestamp installedOn;
 
   @Basic
   @Column(name = "execution_time")
-  public Integer getExecutionTime() {
-    return executionTime;
-  }
+  private Integer executionTime;
 
   @Basic
   @Column(name = "success")
-  public boolean isSuccess() {
-    return success;
-  }
+  private boolean success;
 }

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModFile.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModFile.java
@@ -1,6 +1,7 @@
 package com.faforever.api.featuredmods;
 
 import com.yahoo.elide.annotation.Exclude;
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Immutable;
 
@@ -10,6 +11,7 @@ import javax.persistence.EntityListeners;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 
+@Getter
 @Setter
 @Immutable
 @Entity
@@ -18,73 +20,37 @@ import javax.persistence.Transient;
 // a native query instead. This is why the columns here can't be found in any table.
 public class FeaturedModFile {
 
-  private int id;
-  private String group;
-  private String md5;
-  private String name;
-  private String originalFileName;
-  private int version;
-  // Enriched in FeaturedModFileEnricher
-  private String url;
-  private String folderName;
-  private short fileId;
-
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "\"group\"")
-  public String getGroup() {
-    return group;
-  }
+  private String group;
 
   @Column(name = "md5")
-  public String getMd5() {
-    return md5;
-  }
+  private String md5;
 
-  /**
-   * Name of the file on the client's file system.
-   */
+  // Name of the file on the client's file system.
   @Column(name = "name")
-  public String getName() {
-    return name;
-  }
+  private String name;
 
-
-  /**
-   * Name of the file on the server's file system.
-   */
+  // Name of the file on the server's file system.
   @Column(name = "fileName")
   @Exclude
-  public String getOriginalFileName() {
-    return originalFileName;
-  }
+  private String originalFileName;
 
   @Column(name = "version")
-  public int getVersion() {
-    return version;
-  }
+  private int version;
 
   @Column(name = "fileId")
-  public short getFileId() {
-    return fileId;
-  }
+  private short fileId;
 
   @Transient
   // Enriched by FeaturedModFileEnricher
-  public String getUrl() {
-    return url;
-  }
+  private String url;
 
-  /**
-   * Returns the name of the folder on the server in which the file resides (e.g. {@code updates_faf_files}). Used by
-   * the {@link FeaturedModFileEnricher}.
-   */
+  // Name of the folder on the server in which the file resides (e.g. {@code updates_faf_files}).
+  // Used by the FeaturedModFileEnricher
   @Column(name = "folderName")
-  public String getFolderName() {
-    return folderName;
-  }
+  private String folderName;
 }

--- a/src/main/java/com/faforever/api/leaderboard/GlobalLeaderboardEntry.java
+++ b/src/main/java/com/faforever/api/leaderboard/GlobalLeaderboardEntry.java
@@ -1,5 +1,6 @@
 package com.faforever.api.leaderboard;
 
+import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Immutable;
 
@@ -8,46 +9,29 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+@Getter
 @Setter
 @Entity
 @Table(name = "global_rating")
 @Immutable
 public class GlobalLeaderboardEntry {
-  private int id;
-  private String playerName;
-  private Float mean;
-  private Float deviation;
-  private short numGames;
-  private int rank;
 
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "login")
-  public String getPlayerName() {
-    return playerName;
-  }
+  private String playerName;
 
   @Column(name = "mean")
-  public Float getMean() {
-    return mean;
-  }
+  private Float mean;
 
   @Column(name = "deviation")
-  public Float getDeviation() {
-    return deviation;
-  }
+  private Float deviation;
 
   @Column(name = "numGames")
-  public short getNumGames() {
-    return numGames;
-  }
+  private short numGames;
 
   @Column(name = "rank")
-  public int getRank() {
-    return rank;
-  }
+  private int rank;
 }

--- a/src/main/java/com/faforever/api/leaderboard/Ladder1v1LeaderboardEntry.java
+++ b/src/main/java/com/faforever/api/leaderboard/Ladder1v1LeaderboardEntry.java
@@ -1,5 +1,6 @@
 package com.faforever.api.leaderboard;
 
+import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -7,51 +8,31 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+@Getter
 @Setter
 @Entity
 @Table(name = "ladder1v1_rating")
 public class Ladder1v1LeaderboardEntry {
-  private int id;
-  private String playerName;
-  private Float mean;
-  private Float deviation;
-  private short numGames;
-  private short wonGames;
-  private int rank;
 
   @Id
   @Column(name = "id")
-  public int getId() {
-    return id;
-  }
+  private int id;
 
   @Column(name = "login")
-  public String getPlayerName() {
-    return playerName;
-  }
+  private String playerName;
 
   @Column(name = "mean")
-  public Float getMean() {
-    return mean;
-  }
+  private Float mean;
 
   @Column(name = "deviation")
-  public Float getDeviation() {
-    return deviation;
-  }
+  private Float deviation;
 
   @Column(name = "numGames")
-  public short getNumGames() {
-    return numGames;
-  }
+  private short numGames;
 
   @Column(name = "winGames")
-  public short getWonGames() {
-    return wonGames;
-  }
+  private short wonGames;
 
   @Column(name = "rank")
-  public int getRank() {
-    return rank;
-  }
+  private int rank;
 }


### PR DESCRIPTION
Closes #346 

Migrate all entity annotations from property to field level and use Lombok for the Getters.

WIP: After moving the annotations there are 8 failing integration tests. The issue seems to be related to the lazy-fetched collections (e.g. UserNote.java). The tests passed when I replaced `repository.getOne(id)` with `repository.findById(id)` inside the tests and changed the fetch strategy of some collections from Lazy to Eager. I think Elide has a problem using Hibernate Proxy objects when field access type is used, but I was able to set up a new Spring Boot and Elide project (without Spring Security) and I couldn't reproduce the problem, so I can't confirm yet.

This [issue](https://github.com/yahoo/elide/issues/844) might be related, but I can't confirm for sure as the id returned in our case is `0`, not `null`, and we're having problems mostly with the ManyToOne relationships.