### PR TITLE
Add checks for vault bans on uploading maps and mods (fixes #380)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
   - git clone https://github.com/FAForever/faf-stack.git faf-stack
     && pushd faf-stack
-    && git checkout 1c9b788
+    && git checkout 8686b24
     && cp -r config.template config
     && cp .env.template .env
     && ./scripts/init-db.sh

--- a/src/main/java/com/faforever/api/data/domain/BanLevel.java
+++ b/src/main/java/com/faforever/api/data/domain/BanLevel.java
@@ -1,5 +1,5 @@
 package com.faforever.api.data.domain;
 
 public enum BanLevel {
-  CHAT, GLOBAL
+  CHAT, GLOBAL, VAULT
 }

--- a/src/main/java/com/faforever/api/data/domain/Login.java
+++ b/src/main/java/com/faforever/api/data/domain/Login.java
@@ -19,6 +19,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Transient;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -91,6 +92,13 @@ public abstract class Login extends AbstractEntity implements OwnableEntity {
   @Transient
   public Set<BanInfo> getActiveBans() {
     return getBans().stream().filter(ban -> ban.getBanStatus() == BanStatus.BANNED).collect(Collectors.toSet());
+  }
+
+  @Transient
+  public Optional<BanInfo> getActiveBanOf(BanLevel banLevel) {
+    return getActiveBans().stream()
+      .filter(ban -> ban.getLevel() == banLevel)
+      .findFirst();
   }
 
   @Transient

--- a/src/main/java/com/faforever/api/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/faforever/api/error/GlobalControllerExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.client.HttpClientErrorException.Forbidden;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import javax.validation.ConstraintViolationException;
@@ -89,7 +90,7 @@ class GlobalControllerExceptionHandler {
   }
 
 
-  @ExceptionHandler(AccessDeniedException.class)
+  @ExceptionHandler({AccessDeniedException.class, Forbidden.class})
   @ResponseStatus(HttpStatus.FORBIDDEN)
   @ResponseBody
   public ErrorResponse processAccessDeniedException(Throwable ex) throws MissingServletRequestPartException {
@@ -98,7 +99,7 @@ class GlobalControllerExceptionHandler {
     ErrorResponse response = new ErrorResponse();
     response.addError(new ErrorResult(
       String.valueOf(HttpStatus.FORBIDDEN.value()),
-      ex.getClass().getName(),
+      "You are not allowed to access this resource.",
       ex.getMessage()
     ));
     return response;

--- a/src/main/java/com/faforever/api/map/MapService.java
+++ b/src/main/java/com/faforever/api/map/MapService.java
@@ -202,9 +202,7 @@ public class MapService {
   }
 
   private void checkAuthorVaultBan(Player author) {
-    author.getActiveBans().stream()
-      .filter(ban -> ban.getLevel() == BanLevel.VAULT)
-      .findFirst()
+    author.getActiveBanOf(BanLevel.VAULT)
       .ifPresent((banInfo) -> {
         String message = banInfo.getDuration() == BanDurationType.PERMANENT ?
           "You are permanently banned from uploading maps to the vault." :

--- a/src/main/java/com/faforever/api/mod/ModService.java
+++ b/src/main/java/com/faforever/api/mod/ModService.java
@@ -171,9 +171,7 @@ public class ModService {
   }
 
   private void checkUploaderVaultBan(Player uploader) {
-    uploader.getActiveBans().stream()
-      .filter(ban -> ban.getLevel() == BanLevel.VAULT)
-      .findFirst()
+    uploader.getActiveBanOf(BanLevel.VAULT)
       .ifPresent((banInfo) -> {
         String message = banInfo.getDuration() == BanDurationType.PERMANENT ?
           "You are permanently banned from uploading mods to the vault." :

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -9,7 +9,7 @@ faf-api:
   challonge:
     key: ${CHALLONGE_KEY:}
   database:
-    schema-version: ${DATABASE_SCHEMA_VERSION:84}
+    schema-version: ${DATABASE_SCHEMA_VERSION:85}
   mautic:
     base-url: ${MAUTIC_BASE_URL:false}
     client-id: ${MAUTIC_CLIENT_ID:false}

--- a/src/test/java/com/faforever/api/map/MapServiceTest.java
+++ b/src/test/java/com/faforever/api/map/MapServiceTest.java
@@ -3,6 +3,8 @@ package com.faforever.api.map;
 import com.faforever.api.config.FafApiProperties;
 import com.faforever.api.config.FafApiProperties.Map;
 import com.faforever.api.content.ContentService;
+import com.faforever.api.data.domain.BanInfo;
+import com.faforever.api.data.domain.BanLevel;
 import com.faforever.api.data.domain.MapVersion;
 import com.faforever.api.data.domain.Player;
 import com.faforever.api.error.ApiException;
@@ -22,6 +24,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.HttpClientErrorException.Forbidden;
 import org.thymeleaf.util.StringUtils;
 
 import java.io.IOException;
@@ -33,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -201,6 +205,18 @@ public class MapServiceTest {
 
       assertThat(mapLineError.getArgs().length, is(1));
       assertThat(mapLineError.getArgs()[0], is("map = '/maps/mirage/mirage.scmap'"));
+    }
+
+    @Test
+    void authorBannedFromVault() {
+      when(author.getActiveBans()).thenReturn(Set.of(
+        new BanInfo()
+          .setLevel(BanLevel.VAULT)
+      ));
+
+      InputStream mapData = loadMapAsInputSteam("command_conquer_rush.v0007.zip");
+      assertThrows(Forbidden.class, () -> instance.uploadMap(mapData, "command_conquer_rush.v0007.zip", author, true));
+      verify(mapRepository, never()).save(any(com.faforever.api.data.domain.Map.class));
     }
   }
 

--- a/src/test/java/com/faforever/api/map/MapServiceTest.java
+++ b/src/test/java/com/faforever/api/map/MapServiceTest.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -209,7 +208,7 @@ public class MapServiceTest {
 
     @Test
     void authorBannedFromVault() {
-      when(author.getActiveBans()).thenReturn(Set.of(
+      when(author.getActiveBanOf(BanLevel.VAULT)).thenReturn(Optional.of(
         new BanInfo()
           .setLevel(BanLevel.VAULT)
       ));

--- a/src/test/java/com/faforever/api/mod/ModServiceTest.java
+++ b/src/test/java/com/faforever/api/mod/ModServiceTest.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -120,7 +119,7 @@ public class ModServiceTest {
     Path uploadedFile = prepareMod(TEST_MOD);
 
     Player uploader = mock(Player.class);
-    when(uploader.getActiveBans()).thenReturn(Set.of(
+    when(uploader.getActiveBanOf(BanLevel.VAULT)).thenReturn(Optional.of(
       new BanInfo()
         .setLevel(BanLevel.VAULT)
     ));

--- a/src/test/java/com/faforever/api/mod/ModServiceTest.java
+++ b/src/test/java/com/faforever/api/mod/ModServiceTest.java
@@ -1,6 +1,8 @@
 package com.faforever.api.mod;
 
 import com.faforever.api.config.FafApiProperties;
+import com.faforever.api.data.domain.BanInfo;
+import com.faforever.api.data.domain.BanLevel;
 import com.faforever.api.data.domain.Mod;
 import com.faforever.api.data.domain.ModVersion;
 import com.faforever.api.data.domain.Player;
@@ -19,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Example;
+import org.springframework.web.client.HttpClientErrorException.Forbidden;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -26,11 +29,13 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -108,6 +113,21 @@ public class ModServiceTest {
     expectedException.expect(ApiExceptionMatcher.hasErrorCode(ErrorCode.MOD_UID_EXISTS));
 
     instance.processUploadedMod(uploadedFile, new Player());
+  }
+
+  @Test
+  public void testUploaderVaultBanned() throws Exception {
+    Path uploadedFile = prepareMod(TEST_MOD);
+
+    Player uploader = mock(Player.class);
+    when(uploader.getActiveBans()).thenReturn(Set.of(
+      new BanInfo()
+        .setLevel(BanLevel.VAULT)
+    ));
+
+    expectedException.expect(Forbidden.class);
+
+    instance.processUploadedMod(uploadedFile, uploader);
   }
 
   @Test


### PR DESCRIPTION
Error response looks like this:

```
{
    "requestId": "6887b2c7-130d-4267-a064-be6dff37cb92",
    "errors": [
        {
            "status": "403",
            "title": "You are not allowed to access this resource.",
            "detail": "You are permanently banned from uploading mods to the vault."
        }
    ]
}
```