### PR TITLE
User service refactor

### DIFF
--- a/src/inttest/java/com/faforever/api/user/UsersControllerTest.java
+++ b/src/inttest/java/com/faforever/api/user/UsersControllerTest.java
@@ -117,8 +117,7 @@ public class UsersControllerTest extends AbstractIntegrationTest {
       post("/users/activate")
         .param("token", token)
         .param("password", NEW_PASSWORD))
-      .andExpect(status().isFound())
-      .andExpect(redirectedUrl("http://localhost/account_activated"));
+      .andExpect(status().isOk());
   }
 
   @Test
@@ -274,8 +273,7 @@ public class UsersControllerTest extends AbstractIntegrationTest {
       post("/users/performPasswordReset")
         .param("token", token)
         .param("newPassword", NEW_PASSWORD))
-      .andExpect(status().isFound())
-      .andExpect(redirectedUrl("http://localhost/password_resetted"));
+      .andExpect(status().isOk());
   }
 
   @Test

--- a/src/inttest/java/com/faforever/api/user/UsersControllerTest.java
+++ b/src/inttest/java/com/faforever/api/user/UsersControllerTest.java
@@ -265,7 +265,7 @@ public class UsersControllerTest extends AbstractIntegrationTest {
 
   @Test
   @WithAnonymousUser
-  public void confirmPasswordReset() throws Exception {
+  public void performPasswordReset() throws Exception {
     String token = fafTokenService.createToken(FafTokenType.PASSWORD_RESET,
       Duration.ofSeconds(100),
       ImmutableMap.of(UserService.KEY_USER_ID, String.valueOf(1)));

--- a/src/inttest/resources/config/application.yml
+++ b/src/inttest/resources/config/application.yml
@@ -53,12 +53,10 @@ faf-api:
     preview-url-format: "http://localhost/mod/preview-url/%s"
   password-reset:
     password-reset-url-format: "http://localhost:8010/users/claimPasswordResetToken/%s"
-    success-redirect-url: "http://localhost/password_resetted"
     subject: "Integration test password reset"
     html-format: "Integration test password reset html body"
   registration:
     activation-url-format: "http://localhost/users/activate?token=%s"
-    success-redirect-url: "http://localhost/account_activated"
     subject: "Integration test registration"
     html-format: "Integration test registration html body"
   link-to-steam:

--- a/src/main/java/com/faforever/api/config/FafApiProperties.java
+++ b/src/main/java/com/faforever/api/config/FafApiProperties.java
@@ -177,7 +177,6 @@ public class FafApiProperties {
     private String activationUrlFormat;
     private String subject;
     private String htmlFormat;
-    private String successRedirectUrl;
   }
 
   @Data
@@ -186,7 +185,6 @@ public class FafApiProperties {
     private String passwordResetUrlFormat;
     private String subject;
     private String htmlFormat;
-    private String successRedirectUrl;
   }
 
   @Data

--- a/src/main/java/com/faforever/api/error/ErrorCode.java
+++ b/src/main/java/com/faforever/api/error/ErrorCode.java
@@ -68,7 +68,7 @@ public enum ErrorCode {
   MOD_UID_EXISTS(159, "Duplicate mod UID", "A mod with UID ''{0}'' already exists."),
   MOD_STRUCTURE_INVALID(160, "Invalid file structure for mod", "Files in the the root level of the zip file are not allowed. Please ensure all files reside inside a folder."),
   MOD_VERSION_NOT_A_NUMBER(161, "Mod version is not a number", "The mod version has to be a whole number like 123, but was ''{0}''"),
-  USERNAME_RESERVED(162, "Invalid account data", "The username ''{0}'' can only be claimed by the original owner within {1, number} months after it has been freed."),
+  USERNAME_RESERVED(162, "Username reserved", "The username ''{0}'' is currently reserved for its previous owner. The reservation expires in {1, number} months."),
   UNKNOWN_IDENTIFIER(163, "Unable to resolve user", "The identifier does neither match a username nor an email: {0}"),
   ALREADY_REGISTERED(164, "Registration failed", "You can't create a new account because you already have one."),
   EMAIL_CHANGE_FAILED_WRONG_PASSWORD(138, "Email change failed", "Your current password did not match."),

--- a/src/main/java/com/faforever/api/security/FafTokenService.java
+++ b/src/main/java/com/faforever/api/security/FafTokenService.java
@@ -107,7 +107,7 @@ public class FafTokenService {
 
     Instant expiresAt = Instant.parse(claims.get(KEY_LIFETIME));
     if (expiresAt.isBefore(Instant.now())) {
-      log.debug("Token of expected type '{}' is invalid: {}", expectedTokenType, token);
+      log.debug("Token already expired at '{}' for token: {}", expiresAt, token);
       throw new ApiException(new Error(ErrorCode.TOKEN_EXPIRED));
     }
 

--- a/src/main/java/com/faforever/api/user/UserService.java
+++ b/src/main/java/com/faforever/api/user/UserService.java
@@ -132,7 +132,7 @@ public class UserService {
         KEY_EMAIL, email
       ));
 
-    String activationUrl = String.format(properties.getRegistration().getActivationUrlFormat(), token);
+    String activationUrl = String.format(properties.getRegistration().getActivationUrlFormat(), username, token);
 
     emailService.sendActivationMail(username, email, activationUrl);
 

--- a/src/main/java/com/faforever/api/user/UserService.java
+++ b/src/main/java/com/faforever/api/user/UserService.java
@@ -191,7 +191,7 @@ public class UserService {
       int minDaysBetweenChange = properties.getUser().getMinimumDaysBetweenUsernameChange();
       nameRecordRepository.getDaysSinceLastNewRecord(user.getId(), minDaysBetweenChange)
         .ifPresent(daysSinceLastRecord -> {
-          throw new ApiException(new Error(ErrorCode.USERNAME_CHANGE_TOO_EARLY, minDaysBetweenChange - daysSinceLastRecord.intValue()));
+          throw new ApiException(new Error(ErrorCode.USERNAME_CHANGE_TOO_EARLY, minDaysBetweenChange - daysSinceLastRecord.intValue() + 1));
         });
 
       int usernameReservationTimeInMonths = properties.getUser().getUsernameReservationTimeInMonths();

--- a/src/main/java/com/faforever/api/user/UserService.java
+++ b/src/main/java/com/faforever/api/user/UserService.java
@@ -19,7 +19,6 @@ import com.faforever.api.security.FafTokenType;
 import com.faforever.api.security.FafUserDetails;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
-import lombok.SneakyThrows;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -125,8 +124,6 @@ public class UserService {
    *   }
    * </pre>
    */
-  @SneakyThrows
-  @SuppressWarnings("unchecked")
   @Transactional
   void activate(String registrationToken, String password, String ipAddress) {
     Map<String, String> claims = fafTokenService.resolveToken(FafTokenType.REGISTRATION, registrationToken);
@@ -262,7 +259,6 @@ public class UserService {
     emailService.sendPasswordResetMail(user.getLogin(), user.getEmail(), passwordResetUrl);
   }
 
-  @SneakyThrows
   void performPasswordReset(String token, String newPassword) {
     log.debug("Trying to reset password with token: {}", token);
     Map<String, String> claims = fafTokenService.resolveToken(FafTokenType.PASSWORD_RESET, token);
@@ -313,7 +309,6 @@ public class UserService {
     return steamService.buildLoginUrl(String.format(properties.getLinkToSteam().getSteamRedirectUrlFormat(), token));
   }
 
-  @SneakyThrows
   public SteamLinkResult linkToSteam(String token, String steamId) {
     log.debug("linkToSteam requested for steamId '{}' with token: {}", steamId, token);
     List<Error> errors = new ArrayList<>();

--- a/src/main/java/com/faforever/api/user/UsersController.java
+++ b/src/main/java/com/faforever/api/user/UsersController.java
@@ -48,20 +48,20 @@ public class UsersController {
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._CREATE_USER + "')")
   public void register(HttpServletRequest request,
                        @RequestParam("username") String username,
-                       @RequestParam("email") String email,
-                       @RequestParam("password") String password) {
+                       @RequestParam("email") String email) {
     if (request.isUserInRole("USER")) {
       throw new ApiException(new Error(ErrorCode.ALREADY_REGISTERED));
     }
 
-    userService.register(username, email, password);
+    userService.register(username, email);
   }
 
   @ApiOperation("Activates a previously registered account.")
-  @RequestMapping(path = "/activate", method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/activate", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
   public void activate(HttpServletRequest request, HttpServletResponse response,
-                       @RequestParam("token") String token) throws IOException {
-    userService.activate(token, RemoteAddressUtil.getRemoteAddress(request));
+                       @RequestParam("token") String registrationToken,
+                       @RequestParam("password") String password) throws IOException {
+    userService.activate(registrationToken, password, RemoteAddressUtil.getRemoteAddress(request));
     response.sendRedirect(fafApiProperties.getRegistration().getSuccessRedirectUrl());
   }
 
@@ -95,18 +95,18 @@ public class UsersController {
   }
 
 
-  @ApiOperation("Sends a password reset to the username OR email linked by this account.")
-  @RequestMapping(path = "/resetPassword", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
-  public void resetPassword(@RequestParam("identifier") String identifier,
-                            @RequestParam("newPassword") String newPassword) {
-    userService.resetPassword(identifier, newPassword);
+  @ApiOperation("Sends a password reset request to the username OR email linked by this account.")
+  @RequestMapping(path = "/requestPasswordReset", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  public void requestPasswordReset(@RequestParam("identifier") String identifier) {
+    userService.requestPasswordPasswordReset(identifier);
   }
 
   @ApiOperation("Sets a new password for an account.")
-  @RequestMapping(path = "/confirmPasswordReset", method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
-  public void claimPasswordResetToken(HttpServletResponse response,
-                                      @RequestParam("token") String token) throws IOException {
-    userService.claimPasswordResetToken(token);
+  @RequestMapping(path = "/performPasswordReset", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  public void performPasswordReset(HttpServletResponse response,
+                                   @RequestParam("token") String token,
+                                   @RequestParam("newPassword") String newPassword) throws IOException {
+    userService.performPasswordReset(token, newPassword);
     response.sendRedirect(fafApiProperties.getPasswordReset().getSuccessRedirectUrl());
   }
 

--- a/src/main/java/com/faforever/api/user/UsersController.java
+++ b/src/main/java/com/faforever/api/user/UsersController.java
@@ -92,7 +92,7 @@ public class UsersController {
   @ApiOperation("Sends a password reset request to the username OR email linked by this account.")
   @RequestMapping(path = "/requestPasswordReset", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public void requestPasswordReset(@RequestParam("identifier") String identifier) {
-    userService.requestPasswordPasswordReset(identifier);
+    userService.requestPasswordReset(identifier);
   }
 
   @ApiOperation("Sets a new password for an account.")

--- a/src/main/java/com/faforever/api/user/UsersController.java
+++ b/src/main/java/com/faforever/api/user/UsersController.java
@@ -11,6 +11,7 @@ import com.faforever.api.utils.RemoteAddressUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,25 +27,19 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @RestController
 @RequestMapping(path = "/users")
+@RequiredArgsConstructor
 public class UsersController {
   private final FafApiProperties fafApiProperties;
   private final UserService userService;
   private final SteamService steamService;
   private final ObjectMapper objectMapper;
 
-  public UsersController(FafApiProperties fafApiProperties, UserService userService, SteamService steamService, ObjectMapper objectMapper) {
-    this.fafApiProperties = fafApiProperties;
-    this.userService = userService;
-    this.steamService = steamService;
-    this.objectMapper = objectMapper;
-  }
-
   @ApiOperation("Registers a new account that needs to be activated.")
-  @RequestMapping(path = "/register", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/register", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._CREATE_USER + "')")
   public void register(HttpServletRequest request,
                        @RequestParam("username") String username,
@@ -57,7 +52,7 @@ public class UsersController {
   }
 
   @ApiOperation("Activates a previously registered account.")
-  @RequestMapping(path = "/activate", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/activate", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public void activate(HttpServletRequest request, HttpServletResponse response,
                        @RequestParam("token") String registrationToken,
                        @RequestParam("password") String password) throws IOException {
@@ -67,42 +62,42 @@ public class UsersController {
 
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._WRITE_ACCOUNT_DATA + "') and hasRole('ROLE_USER')")
   @ApiOperation("Changes the password of a previously registered account.")
-  @RequestMapping(path = "/changePassword", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/changePassword", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public void changePassword(@RequestParam("currentPassword") String currentPassword, @RequestParam("newPassword") String newPassword, Authentication authentication) {
     userService.changePassword(currentPassword, newPassword, userService.getUser(authentication));
   }
 
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._WRITE_ACCOUNT_DATA + "') and hasRole('ROLE_USER')")
   @ApiOperation("Changes the login of a previously registered account.")
-  @RequestMapping(path = "/changeUsername", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/changeUsername", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public void changeLogin(HttpServletRequest request, @RequestParam("newUsername") String newUsername, Authentication authentication) {
     userService.changeLogin(newUsername, userService.getUser(authentication), RemoteAddressUtil.getRemoteAddress(request));
   }
 
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._WRITE_ACCOUNT_DATA + "') and hasAnyRole('ROLE_MODERATOR', 'ROLE_ADMINISTRATOR')")
   @ApiOperation("Force the change of the login of a user with the given userId.")
-  @RequestMapping(path = "/{userId}/forceChangeUsername", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/{userId}/forceChangeUsername", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public void forceChangeLogin(HttpServletRequest request, @RequestParam("newUsername") String newUsername, @PathVariable("userId") String userId) {
-    User user = userService.getUser(Integer.valueOf(userId));
+    User user = userService.getUser(Integer.parseInt(userId));
     userService.changeLoginForced(newUsername, user, RemoteAddressUtil.getRemoteAddress(request));
   }
 
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._WRITE_ACCOUNT_DATA + "') and hasRole('ROLE_USER')")
   @ApiOperation("Changes the email of a previously registered account.")
-  @RequestMapping(path = "/changeEmail", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/changeEmail", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public void changeEmail(HttpServletRequest request, @RequestParam("currentPassword") String currentPassword, @RequestParam("newEmail") String newEmail, Authentication authentication) {
     userService.changeEmail(currentPassword, newEmail, userService.getUser(authentication), RemoteAddressUtil.getRemoteAddress(request));
   }
 
 
   @ApiOperation("Sends a password reset request to the username OR email linked by this account.")
-  @RequestMapping(path = "/requestPasswordReset", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/requestPasswordReset", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public void requestPasswordReset(@RequestParam("identifier") String identifier) {
     userService.requestPasswordPasswordReset(identifier);
   }
 
   @ApiOperation("Sets a new password for an account.")
-  @RequestMapping(path = "/performPasswordReset", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/performPasswordReset", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public void performPasswordReset(HttpServletResponse response,
                                    @RequestParam("token") String token,
                                    @RequestParam("newPassword") String newPassword) throws IOException {
@@ -112,14 +107,14 @@ public class UsersController {
 
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._WRITE_ACCOUNT_DATA + "') and hasRole('ROLE_USER')")
   @ApiOperation("Creates an URL to the steam platform to initiate the Link To Steam process.")
-  @RequestMapping(path = "/buildSteamLinkUrl", method = RequestMethod.POST, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/buildSteamLinkUrl", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
   public Map<String, Serializable> buildSteamLinkUrl(Authentication authentication, @RequestParam("callbackUrl") String callbackUrl) {
     String steamUrl = userService.buildSteamLinkUrl(userService.getUser(authentication), callbackUrl);
     return ImmutableMap.of("steamUrl", steamUrl);
   }
 
   @ApiOperation("Processes the Steam redirect and creates the steam link in the user account.")
-  @RequestMapping(path = "/linkToSteam", method = RequestMethod.GET, produces = APPLICATION_JSON_UTF8_VALUE)
+  @RequestMapping(path = "/linkToSteam", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
   public void linkToSteam(HttpServletRequest request,
                           HttpServletResponse response,
                           @RequestParam("token") String token) throws IOException {

--- a/src/main/java/com/faforever/api/user/UsersController.java
+++ b/src/main/java/com/faforever/api/user/UsersController.java
@@ -57,7 +57,6 @@ public class UsersController {
                        @RequestParam("token") String registrationToken,
                        @RequestParam("password") String password) throws IOException {
     userService.activate(registrationToken, password, RemoteAddressUtil.getRemoteAddress(request));
-    response.sendRedirect(fafApiProperties.getRegistration().getSuccessRedirectUrl());
   }
 
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._WRITE_ACCOUNT_DATA + "') and hasRole('ROLE_USER')")
@@ -102,7 +101,6 @@ public class UsersController {
                                    @RequestParam("token") String token,
                                    @RequestParam("newPassword") String newPassword) throws IOException {
     userService.performPasswordReset(token, newPassword);
-    response.sendRedirect(fafApiProperties.getPasswordReset().getSuccessRedirectUrl());
   }
 
   @PreAuthorize("#oauth2.hasScope('" + OAuthScope._WRITE_ACCOUNT_DATA + "') and hasRole('ROLE_USER')")

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -39,13 +39,11 @@ faf-api:
     from-email-name: ${EMAIL_FROM_NAME:FAForever}
     from-email-address: ${EMAIL_FROM_ADDRESS:faf@example.com}
   registration:
-    activation-url-format: ${ACTIVATION_URL_FORMAT:http://localhost:8010/users/activate?token=%s}
-    success-redirect-url: ${ACTIVATION_SUCCESS_REDIRECT_URL:http://localhost:8020/account_activated}
+    activation-url-format: ${ACTIVATION_URL_FORMAT:http://localhost:8010/users/activate?username=%s&token=%s}
     subject: ${REGISTRATION_EMAIL_SUBJECT:FAF user registration}
     html-format: ${REGISTRATION_EMAIL_BODY:Registration email body}
   password-reset:
     password-reset-url-format: ${PASSWORD_RESET_URL_FORMAT:http://localhost:8010/users/claimPasswordResetToken?username=%s&token=%s}
-    success-redirect-url: ${PASSWORD_RESET_SUCCESS_REDIRECT_URL:http://localhost:8020/password_resetted}
     subject: ${PASSWORD_RESET_EMAIL_SUBJECT:FAF password reset}
     html-format: ${PASSWORD_RESET_EMAIL_BODY:Registration email body}
   steam:

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -44,7 +44,7 @@ faf-api:
     subject: ${REGISTRATION_EMAIL_SUBJECT:FAF user registration}
     html-format: ${REGISTRATION_EMAIL_BODY:Registration email body}
   password-reset:
-    password-reset-url-format: ${PASSWORD_RESET_URL_FORMAT:http://localhost:8010/users/claimPasswordResetToken?token=%s}
+    password-reset-url-format: ${PASSWORD_RESET_URL_FORMAT:http://localhost:8010/users/claimPasswordResetToken?username=%s&token=%s}
     success-redirect-url: ${PASSWORD_RESET_SUCCESS_REDIRECT_URL:http://localhost:8020/password_resetted}
     subject: ${PASSWORD_RESET_EMAIL_SUBJECT:FAF password reset}
     html-format: ${PASSWORD_RESET_EMAIL_BODY:Registration email body}

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -41,12 +41,10 @@ faf-api:
     from-email-address: ${EMAIL_FROM_ADDRESS}
   registration:
     activation-url-format: ${ACTIVATION_URL_FORMAT}
-    success-redirect-url: ${ACTIVATION_SUCCESS_REDIRECT_URL}
     subject: ${REGISTRATION_EMAIL_SUBJECT}
     html-format: ${REGISTRATION_EMAIL_BODY}
   password-reset:
     password-reset-url-format: ${PASSWORD_RESET_URL_FORMAT}
-    success-redirect-url: ${PASSWORD_RESET_SUCCESS_REDIRECT_URL}
     subject: ${PASSWORD_RESET_EMAIL_SUBJECT}
     html-format: ${PASSWORD_RESET_EMAIL_BODY}
   steam:

--- a/src/test/java/com/faforever/api/user/UserServiceTest.java
+++ b/src/test/java/com/faforever/api/user/UserServiceTest.java
@@ -128,7 +128,7 @@ public class UserServiceTest {
 
     ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
     verify(emailService).sendActivationMail(eq(TEST_USERNAME), eq(TEST_CURRENT_EMAIL), urlCaptor.capture());
-    assertThat(urlCaptor.getValue(), is(String.format(ACTIVATION_URL_FORMAT, TOKEN_VALUE)));
+    assertThat(urlCaptor.getValue(), is(String.format(ACTIVATION_URL_FORMAT, TEST_USERNAME, TOKEN_VALUE)));
 
     verifyNoMoreInteractions(mauticService);
   }

--- a/src/test/java/com/faforever/api/user/UserServiceTest.java
+++ b/src/test/java/com/faforever/api/user/UserServiceTest.java
@@ -18,11 +18,13 @@ import com.faforever.api.security.FafTokenType;
 import com.faforever.api.user.UserService.SteamLinkResult;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -93,6 +95,8 @@ public class UserServiceTest {
   private GlobalRatingRepository globalRatingRepository;
   @Mock
   private Ladder1v1RatingRepository ladder1v1RatingRepository;
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private MeterRegistry meterRegistry;
 
   private FafApiProperties properties;
 
@@ -108,7 +112,7 @@ public class UserServiceTest {
   public void setUp() {
     properties = new FafApiProperties();
     properties.getLinkToSteam().setSteamRedirectUrlFormat("%s");
-    instance = new UserService(emailService, playerRepository, userRepository, nameRecordRepository, properties, anopeUserRepository, fafTokenService, steamService, Optional.of(mauticService), globalRatingRepository, ladder1v1RatingRepository);
+    instance = new UserService(emailService, playerRepository, userRepository, nameRecordRepository, properties, anopeUserRepository, fafTokenService, steamService, Optional.of(mauticService), globalRatingRepository, ladder1v1RatingRepository, meterRegistry);
   }
 
   @Test
@@ -348,7 +352,7 @@ public class UserServiceTest {
     when(fafTokenService.createToken(any(), any(), any())).thenReturn(TOKEN_VALUE);
     when(userRepository.findOneByLogin(TEST_USERNAME)).thenReturn(Optional.of(user));
 
-    instance.requestPasswordPasswordReset(TEST_USERNAME);
+    instance.requestPasswordReset(TEST_USERNAME);
 
     verify(userRepository).findOneByLogin(TEST_USERNAME);
 
@@ -373,7 +377,7 @@ public class UserServiceTest {
     when(fafTokenService.createToken(any(), any(), any())).thenReturn(TOKEN_VALUE);
     when(userRepository.findOneByEmail(TEST_CURRENT_EMAIL)).thenReturn(Optional.of(user));
 
-    instance.requestPasswordPasswordReset(TEST_CURRENT_EMAIL);
+    instance.requestPasswordReset(TEST_CURRENT_EMAIL);
 
     verify(userRepository).findOneByEmail(TEST_CURRENT_EMAIL);
 
@@ -393,7 +397,7 @@ public class UserServiceTest {
     when(userRepository.findOneByEmail(TEST_CURRENT_EMAIL)).thenReturn(Optional.empty());
     when(userRepository.findOneByEmail(TEST_CURRENT_EMAIL)).thenReturn(Optional.empty());
 
-    ApiException exception = assertThrows(ApiException.class, () -> instance.requestPasswordPasswordReset(TEST_CURRENT_EMAIL));
+    ApiException exception = assertThrows(ApiException.class, () -> instance.requestPasswordReset(TEST_CURRENT_EMAIL));
     assertThat(exception, hasErrorCode(ErrorCode.UNKNOWN_IDENTIFIER));
   }
 


### PR DESCRIPTION
Backward incompatible changes:
- change account activation and and password reset confirmation endpoints name and method (POST)
- PASSWORD_RESET_URL_FORMAT config has changed (needs to point to a new confirmation page on the website now )
- ACTIVATION_URL_FORMAT config has changed (needs to point to a new confirmation page on the website now )
- ACTIVATION_SUCCESS_REDIRECT_URL dropped
- PASSWORD_RESET_SUCCESS_REDIRECT_URL dropped

To Do
- [ ] ~~Add password reset via Steam~~
- [x] Add prometheus metrics