### PR TITLE
Resync account on demand

### DIFF
--- a/src/inttest/java/com/faforever/api/user/UsersControllerTest.java
+++ b/src/inttest/java/com/faforever/api/user/UsersControllerTest.java
@@ -504,4 +504,13 @@ public class UsersControllerTest extends AbstractIntegrationTest {
 
     assertThat(userRepository.getOne(2).getLogin(), is(NEW_USER));
   }
+
+  @Test
+  @WithUserDetails(AUTH_USER)
+  public void resyncAccountSuccess() throws Exception {
+    mockMvc.perform(
+      post("/users/resyncAccount")
+        .with(getOAuthTokenWithoutUser(OAuthScope._WRITE_ACCOUNT_DATA)))
+      .andExpect(status().isOk());
+  }
 }

--- a/src/main/java/com/faforever/api/user/UserService.java
+++ b/src/main/java/com/faforever/api/user/UserService.java
@@ -265,6 +265,11 @@ public class UserService {
     broadcastUserChange(user);
   }
 
+  public void resynchronizeAccount(User user) {
+    log.debug("Resynchronizing account data for user ''{}''", user.getLogin());
+    broadcastUserChange(user);
+  }
+
   private void broadcastUserChange(User user) {
     UserUpdatedEvent userUpdatedEvent = new UserUpdatedEvent(
       user,

--- a/src/main/java/com/faforever/api/user/UsersController.java
+++ b/src/main/java/com/faforever/api/user/UsersController.java
@@ -127,4 +127,11 @@ public class UsersController {
 
     response.sendRedirect(result.getCallbackUrl());
   }
+
+  @PreAuthorize("#oauth2.hasScope('" + OAuthScope._WRITE_ACCOUNT_DATA + "') and hasRole('ROLE_USER')")
+  @ApiOperation("Trigger resynchronisation of the users account with all related systems.")
+  @RequestMapping(path = "/resyncAccount", method = RequestMethod.POST, produces = APPLICATION_JSON_VALUE)
+  public void resynchronizeAccount(Authentication authentication) {
+    userService.resynchronizeAccount(userService.getUser(authentication));
+  }
 }

--- a/src/test/java/com/faforever/api/user/UserServiceTest.java
+++ b/src/test/java/com/faforever/api/user/UserServiceTest.java
@@ -534,4 +534,13 @@ public class UserServiceTest {
     verifyNoMoreInteractions(eventPublisher);
   }
 
+  @Test
+  public void testResyncAccount() {
+    User user = createUser(TEST_USERID, TEST_USERNAME, TEST_CURRENT_PASSWORD, TEST_CURRENT_EMAIL);
+
+    instance.resynchronizeAccount(user);
+
+    verify(eventPublisher).publishEvent(any(UserUpdatedEvent.class));
+  }
+
 }


### PR DESCRIPTION
Due to bugs and configuration issues not all accounts are synchronized across all systems (NodeBB, Mautic).
This at least allows player to manually sync their account once more.