### PR TITLE
Bugfix/statistics null

### DIFF
--- a/src/main/java/com/faforever/api/data/domain/MapStatistics.java
+++ b/src/main/java/com/faforever/api/data/domain/MapStatistics.java
@@ -20,10 +20,10 @@ import javax.persistence.Table;
 public class MapStatistics {
   public static final String TYPE_NAME = "mapStatistics";
 
-  private int id;
-  private int downloads;
-  private int plays;
-  private int draws;
+  private Integer id;
+  private Integer downloads;
+  private Integer plays;
+  private Integer draws;
   private Map map;
 
   @Id

--- a/src/main/java/com/faforever/api/data/domain/MapVersionStatistics.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersionStatistics.java
@@ -27,22 +27,22 @@ public class MapVersionStatistics {
 
   @Id
   @Column(name = "map_version_id")
-  public int getId() {
+  public Integer getId() {
     return id;
   }
 
   @Column(name = "downloads")
-  public int getDownloads() {
+  public Integer getDownloads() {
     return downloads;
   }
 
   @Column(name = "plays")
-  public int getPlays() {
+  public Integer getPlays() {
     return plays;
   }
 
   @Column(name = "draws")
-  public int getDraws() {
+  public Integer getDraws() {
     return draws;
   }
 

--- a/src/main/java/com/faforever/api/data/domain/MapVersionStatistics.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersionStatistics.java
@@ -19,10 +19,10 @@ import javax.persistence.Table;
 @Include(type = "mapVersionStatistics")
 @Immutable
 public class MapVersionStatistics {
-  private int id;
-  private int downloads;
-  private int plays;
-  private int draws;
+  private Integer id;
+  private Integer downloads;
+  private Integer plays;
+  private Integer draws;
   private MapVersion mapVersion;
 
   @Id


### PR DESCRIPTION
make statistics return the boxed types.

Currently when the statistics views is sorted using another table the downloads and draws returns null in mysql instead of 0 because of some bug or weird behavior. This currently prevents us from fully depreciating the statistics objects in the client. Setting these to the boxed types will allow depreciating in the client and the ultimate removal from the api.