### PR TITLE
turn off jar task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,9 @@ group = 'faforever'
 sourceCompatibility = 16
 targetCompatibility = 16
 
+bootJar.enabled = true
+jar.enabled = false
+
 repositories {
   mavenCentral()
   maven { url "https://jitpack.io" }


### PR DESCRIPTION
Currently multiple jars are being created in the build task. The bootJar task creates a jar with the app name and version while the jar task creates a jar with the app name version and classifier. This causes issues during our building of the docker image as there are two jars to copy. This should fix this by only running the bootJar task.

Other options to fix the docker build would be to more clearly specify the name of the jar or to fix the jar task so that it does not add the classifier of "plain" o the jar name,