### PR TITLE
Hack in support for OpenID scopes

### DIFF
--- a/src/main/java/com/faforever/api/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/faforever/api/config/security/WebSecurityConfig.java
@@ -1,9 +1,7 @@
 package com.faforever.api.config.security;
 
-import com.faforever.api.config.ApplicationProfile;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -31,14 +29,6 @@ import java.util.regex.Pattern;
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 @EnableWebSecurity
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
-
-  @Inject
-  @Profile(ApplicationProfile.DEVELOPMENT)
-  public void developUserDetails(AuthenticationManagerBuilder auth) throws Exception {
-    auth.inMemoryAuthentication()
-      .withUser("user").password("user").roles("USER")
-      .and().withUser("admin").password("admin").roles("USER", "ADMIN");
-  }
 
   @Inject
   public void prodUserDetails(AuthenticationManagerBuilder auth, UserDetailsService userDetailsService) throws Exception {

--- a/src/main/java/com/faforever/api/security/FafUserDetails.java
+++ b/src/main/java/com/faforever/api/security/FafUserDetails.java
@@ -5,19 +5,25 @@ import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
+import java.util.Set;
 
 @Getter
 public class FafUserDetails extends org.springframework.security.core.userdetails.User {
 
   private final int id;
+  /**
+   * Workaround for compatibility with old Spring OAuth2 token AND new OpenID Connect token
+   */
+  private final Set<String> scopes;
 
-  public FafUserDetails(User user, Collection<? extends GrantedAuthority> authorities) {
-    this(user.getId(), user.getLogin(), user.getPassword(), !user.isGlobalBanned(), authorities);
+  public FafUserDetails(User user, Collection<? extends GrantedAuthority> authorities, Set<String> scopes) {
+    this(user.getId(), user.getLogin(), user.getPassword(), !user.isGlobalBanned(), authorities, scopes);
   }
 
-  public FafUserDetails(int id, String username, String password, boolean accountNonLocked, Collection<? extends GrantedAuthority> authorities) {
+  public FafUserDetails(int id, String username, String password, boolean accountNonLocked, Collection<? extends GrantedAuthority> authorities, Set<String> scopes) {
     super(username, password, true, true, true, accountNonLocked, authorities);
     this.id = id;
+    this.scopes = scopes;
   }
 
   public boolean hasPermission(String permission) {

--- a/src/main/java/com/faforever/api/security/FafUserDetailsService.java
+++ b/src/main/java/com/faforever/api/security/FafUserDetailsService.java
@@ -36,7 +36,7 @@ public class FafUserDetailsService implements UserDetailsService {
     authorities.addAll(getUserRoles(user));
     authorities.addAll(getPermissionRoles(user));
 
-    return new FafUserDetails(user, authorities);
+    return new FafUserDetails(user, authorities, Set.of());
   }
 
   private Collection<GrantedAuthority> getUserRoles(User user) {

--- a/src/main/java/com/faforever/api/security/UserSupplier.java
+++ b/src/main/java/com/faforever/api/security/UserSupplier.java
@@ -4,6 +4,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 @Component
@@ -15,7 +16,7 @@ public class UserSupplier implements Supplier<FafUserDetails> {
     if (principal instanceof FafUserDetails) {
       return (FafUserDetails) principal;
     } else {
-      return new FafUserDetails(-1, principal.toString(), null, false, List.of());
+      return new FafUserDetails(-1, principal.toString(), null, false, List.of(), Set.of());
     }
   }
 }

--- a/src/main/java/com/faforever/api/security/elide/permission/FafUserCheck.java
+++ b/src/main/java/com/faforever/api/security/elide/permission/FafUserCheck.java
@@ -33,11 +33,12 @@ abstract class FafUserCheck extends UserCheck {
 
     OAuth2Authentication oAuth2Authentication = ((OAuth2Authentication) authentication);
     OAuth2Request oAuth2Request = oAuth2Authentication.getOAuth2Request();
+    var requestScopes = ((FafUserDetails) oAuth2Authentication.getPrincipal()).getScopes();
 
     List<String> missedScopes = new ArrayList<>();
 
     for (String currentScope : scope) {
-      if (!oAuth2Request.getScope().contains(currentScope)) {
+      if (!requestScopes.contains(currentScope)) {
         missedScopes.add(currentScope);
       }
     }


### PR DESCRIPTION
OpenID token have a different structure than the Spring ones. This workaround makes the API support both.

It's really ugly but the whole OAuth2 code of the API is deprecated anyway.