### PR TITLE
Provide access to leagueSeason nameKey

### DIFF
--- a/src/main/java/com/faforever/api/league/domain/LeagueSeason.java
+++ b/src/main/java/com/faforever/api/league/domain/LeagueSeason.java
@@ -23,6 +23,7 @@ public class LeagueSeason {
   private Integer id;
   private League league;
   private Leaderboard leaderboard;
+  private String nameKey;
   private OffsetDateTime startDate;
   private OffsetDateTime endDate;
 
@@ -43,6 +44,11 @@ public class LeagueSeason {
   @JoinColumn(name = "leaderboard_id")
   public Leaderboard getLeaderboard() {
     return leaderboard;
+  }
+
+  @Column(name = "name_key")
+  public String getNameKey() {
+    return nameKey;
   }
 
   @Column(name = "start_date")


### PR DESCRIPTION
The league season has a nameKey that is currently not exposed on the api. That is probably because we added this column a bit later. I don't know if it is sufficent to alter this one file, so do tell me if I need to do more changes.