### PR TITLE
Closes #505 Team size of matchmaker queues is not available on the api

### DIFF
--- a/src/main/java/com/faforever/api/data/domain/MatchmakerQueue.java
+++ b/src/main/java/com/faforever/api/data/domain/MatchmakerQueue.java
@@ -24,6 +24,7 @@ public class MatchmakerQueue extends AbstractEntity<MatchmakerQueue> {
   private String params;
   private FeaturedMod featuredMod;
   private Leaderboard leaderboard;
+  private int teamSize;
 
   @Column(name = "technical_name")
   @NotNull
@@ -55,4 +56,9 @@ public class MatchmakerQueue extends AbstractEntity<MatchmakerQueue> {
     return leaderboard;
   }
 
+  @Column(name = "team_size")
+  @NotNull
+  public int getTeamSize() {
+    return teamSize;
+  }
 }


### PR DESCRIPTION
Closes #505 Team size of matchmaker queues is not available on the api