### PR TITLE
Remove ability for authors to change a maps ranked status

### DIFF
--- a/src/inttest/java/com/faforever/api/data/MapVersionElideTest.java
+++ b/src/inttest/java/com/faforever/api/data/MapVersionElideTest.java
@@ -102,6 +102,16 @@ public class MapVersionElideTest extends AbstractIntegrationTest {
 
   @WithUserDetails(AUTH_USER)
   @Test
+  public void canUpdateHideToTrueAsEntityOwner() throws Exception {
+    mockMvc.perform(
+        patch("/data/mapVersion/1")
+          .header(HttpHeaders.CONTENT_TYPE, JSON_API_MEDIA_TYPE)
+          .content(MAP_VERSION_HIDE_TRUE_ID_1))
+      .andExpect(status().isNoContent());
+  }
+
+  @WithUserDetails(AUTH_USER)
+  @Test
   public void cannotUpdateHideToFalseAsEntityOwner() throws Exception {
     mockMvc.perform(
       patch("/data/mapVersion/1")
@@ -112,12 +122,12 @@ public class MapVersionElideTest extends AbstractIntegrationTest {
 
   @WithUserDetails(AUTH_USER)
   @Test
-  public void canUpdateRankedToFalseAsEntityOwner() throws Exception {
+  public void cannotUpdateRankedToFalseAsEntityOwner() throws Exception {
     mockMvc.perform(
       patch("/data/mapVersion/1")
         .header(HttpHeaders.CONTENT_TYPE, JSON_API_MEDIA_TYPE)
         .content(MAP_VERSION_RANKED_FALSE_ID_1))
-      .andExpect(status().isNoContent());
+      .andExpect(status().isForbidden());
   }
 
   @WithUserDetails(AUTH_USER)

--- a/src/main/java/com/faforever/api/data/domain/MapVersion.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersion.java
@@ -95,7 +95,7 @@ public class MapVersion extends AbstractEntity<MapVersion> implements OwnableEnt
     return gamesPlayed;
   }
 
-  @UpdatePermission(expression = AdminMapCheck.EXPRESSION + " or (" + IsEntityOwner.EXPRESSION + " and " + BooleanChange.TO_FALSE_EXPRESSION + ")")
+  @UpdatePermission(expression = AdminMapCheck.EXPRESSION)
   @Audit(action = Action.UPDATE, logStatement = "Updated map version `{0}` attribute ranked to: {1}", logExpressions = {"${mapVersion.id}", "${mapVersion.ranked}"})
   @Column(name = "ranked")
   public boolean isRanked() {


### PR DESCRIPTION
Recently there have been more instances of authors changing maps that were originally balanced and ranked to unranked not due to any error with the map balance but to get players to stop playing the old map.

This functionality of hiding the map is largely covered by the ability of authors to hide their maps. After discussion with Balthazar as the creative team councilor he requested that only vault admins be able to update a maps ranked status after being uploaded.

This makes it so that the status of a map being ranked or not is more of a property of the map being balanced.