### PR TITLE
Add size suffix to division image urls

### DIFF
--- a/src/inttest/java/com/faforever/api/league/LeagueSeasonSubdivisionElideTest.java
+++ b/src/inttest/java/com/faforever/api/league/LeagueSeasonSubdivisionElideTest.java
@@ -43,8 +43,8 @@ class LeagueSeasonSubdivisionElideTest extends LeagueAbstractIntegrationTest {
       .andExpect(jsonPath("$.data.attributes.maxRating", is(1000.0)))
       .andExpect(jsonPath("$.data.attributes.highestScore", is(50)))
       .andExpect(jsonPath("$.data.attributes.imageUrl", is("https://example1.com/division_name_1subdivision_name_1.png")))
-      .andExpect(jsonPath("$.data.attributes.mediumImageUrl", is("https://example1.com/medium/division_name_1subdivision_name_1.png")))
-      .andExpect(jsonPath("$.data.attributes.smallImageUrl", is("https://example1.com/small/division_name_1subdivision_name_1.png")));
+      .andExpect(jsonPath("$.data.attributes.mediumImageUrl", is("https://example1.com/medium/division_name_1subdivision_name_1_medium.png")))
+      .andExpect(jsonPath("$.data.attributes.smallImageUrl", is("https://example1.com/small/division_name_1subdivision_name_1_small.png")));
   }
 
   @Test

--- a/src/main/java/com/faforever/api/league/domain/LeagueSeasonDivisionSubdivisionEnricher.java
+++ b/src/main/java/com/faforever/api/league/domain/LeagueSeasonDivisionSubdivisionEnricher.java
@@ -12,10 +12,10 @@ public class LeagueSeasonDivisionSubdivisionEnricher {
   @PostLoad
   public void enhance(LeagueSeasonDivisionSubdivision subdivision) {
     League league = subdivision.getLeagueSeasonDivision().getLeagueSeason().getLeague();
-    String filename = subdivision.getLeagueSeasonDivision().getNameKey() + subdivision.getNameKey() + ".png";
+    String divisionName = subdivision.getLeagueSeasonDivision().getNameKey() + subdivision.getNameKey();
 
-    subdivision.setImageUrl(league.getImageUrl() + filename);
-    subdivision.setMediumImageUrl(league.getMediumImageUrl() + filename);
-    subdivision.setSmallImageUrl(league.getSmallImageUrl() + filename);
+    subdivision.setImageUrl(league.getImageUrl() + divisionName + ".png");
+    subdivision.setMediumImageUrl(league.getMediumImageUrl() + divisionName + "_medium.png");
+    subdivision.setSmallImageUrl(league.getSmallImageUrl() + divisionName + "_small.png");
   }
 }


### PR DESCRIPTION
I forgot that the small and medium images carry an additional suffix in their name.