### PR TITLE
Fix featured mod deployment 

### DIFF
--- a/src/main/java/com/faforever/api/deployment/GitHubDeploymentService.java
+++ b/src/main/java/com/faforever/api/deployment/GitHubDeploymentService.java
@@ -98,8 +98,11 @@ public class GitHubDeploymentService {
   @SneakyThrows
   private void updateDeploymentStatus(long deploymentId, GHRepository repository, GHDeploymentState state, String description) {
     log.debug("Updating deployment status to '{}' with description: {}", state, description);
-    repository.getDeployment(deploymentId)
-      .createStatus(state)
+    if (description.length() > 140) {
+      log.info("Deployment Status description too long truncating");
+      description = description.substring(0, 140);
+    }
+    repository.getDeployment(deploymentId).createStatus(state)
       .description(description)
       .create();
   }

--- a/src/main/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTask.java
+++ b/src/main/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTask.java
@@ -275,14 +275,14 @@ public class LegacyFeaturedModDeploymentTask implements Runnable {
    * content of the directory. If no file ID is available, an empty optional is returned.
    */
   @SneakyThrows
-  private Optional<StagedFile> packFile(Path file, Short version, Path targetFolder, Map<String, Short> fileIds) {
+  private Optional<StagedFile> packFile(Path file, Short version, Path targetFolder, Map<String, Integer> fileIds) {
     String fullFileName = file.getFileName().toString();
     String baseName = FilenameUtils.getBaseName(fullFileName);
     String extension = FilenameUtils.getExtension(fullFileName);
     Path targetFile = targetFolder.resolve(String.format("%s_%d.%s", baseName, version, extension));
     Path tmpFile = toTmpFile(targetFile);
 
-    Short fileId = fileIds.get(fullFileName);
+    Integer fileId = fileIds.get(fullFileName);
     if (fileId == null) {
       log.debug("Skipping file '{}' because there's no file ID available", fullFileName);
       return Optional.empty();

--- a/src/main/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTask.java
+++ b/src/main/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTask.java
@@ -97,7 +97,7 @@ public class LegacyFeaturedModDeploymentTask implements Runnable {
     String branch = featuredMod.getGitBranch();
     boolean allowOverride = Optional.ofNullable(featuredMod.isAllowOverride()).orElse(false);
     String modFilesExtension = featuredMod.getFileExtension();
-    Map<String, Short> fileIds = featuredModService.getFileIds(modName);
+    Map<String, Integer> fileIds = featuredModService.getFileIds(modName);
 
     log.info("Starting deployment of '{}' from '{}', branch '{}', allowOverride '{}', modFilesExtension '{}'",
       modName, repositoryUrl, branch, allowOverride, modFilesExtension);
@@ -147,9 +147,9 @@ public class LegacyFeaturedModDeploymentTask implements Runnable {
    * featured mod.
    */
   @SneakyThrows
-  private Optional<StagedFile> createPatchedExe(short version, Map<String, Short> fileIds, Path targetFolder) {
+  private Optional<StagedFile> createPatchedExe(short version, Map<String, Integer> fileIds, Path targetFolder) {
     String clientFileName = "ForgedAlliance.exe";
-    Short fileId = fileIds.get(clientFileName);
+    Integer fileId = fileIds.get(clientFileName);
     if (fileId == null) {
       log.debug("Skipping '{}' because there's no file ID available", clientFileName);
       return Optional.empty();
@@ -210,7 +210,7 @@ public class LegacyFeaturedModDeploymentTask implements Runnable {
    */
   @SneakyThrows
   @SuppressWarnings("unchecked")
-  private List<StagedFile> packageFiles(Path repositoryDirectory, short version, Map<String, Short> fileIds, Path targetFolder) {
+  private List<StagedFile> packageFiles(Path repositoryDirectory, short version, Map<String, Integer> fileIds, Path targetFolder) {
     updateStatus("Packaging files");
     try (Stream<Path> stream = Files.list(repositoryDirectory)) {
       return stream
@@ -248,14 +248,14 @@ public class LegacyFeaturedModDeploymentTask implements Runnable {
    * content of the directory. If no file ID is available, an empty optional is returned.
    */
   @SneakyThrows
-  private Optional<StagedFile> packDirectory(Path directory, Short version, Path targetFolder, Map<String, Short> fileIds) {
+  private Optional<StagedFile> packDirectory(Path directory, Short version, Path targetFolder, Map<String, Integer> fileIds) {
     String directoryName = directory.getFileName().toString();
     Path targetNxtFile = targetFolder.resolve(String.format("%s.%d.%s", directoryName, version, featuredMod.getFileExtension()));
     Path tmpNxtFile = toTmpFile(targetNxtFile);
 
     // E.g. "effects.nx2"
     String clientFileName = String.format("%s.%s", directoryName, featuredMod.getFileExtension());
-    Short fileId = fileIds.get(clientFileName);
+    Integer fileId = fileIds.get(clientFileName);
     if (fileId == null) {
       log.debug("Skipping folder '{}' because there's no file ID available", directoryName);
       return Optional.empty();
@@ -360,7 +360,7 @@ public class LegacyFeaturedModDeploymentTask implements Runnable {
     /**
      * ID of the file as stored in the database.
      */
-    short fileId,
+    int fileId,
     /**
      * The staged file, already in the correct location, that is ready to be renamed.
      */

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModFile.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModFile.java
@@ -27,7 +27,7 @@ public class FeaturedModFile {
   // Enriched in FeaturedModFileEnricher
   private String url;
   private String folderName;
-  private short fileId;
+  private int fileId;
 
   @Id
   @Column(name = "id")
@@ -69,7 +69,7 @@ public class FeaturedModFile {
   }
 
   @Column(name = "fileId")
-  public short getFileId() {
+  public int getFileId() {
     return fileId;
   }
 

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModService.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModService.java
@@ -40,7 +40,7 @@ public class FeaturedModService {
     legacyFeaturedModFileRepository.save(modName, version, featuredModFiles);
   }
 
-  public Map<String, Short> getFileIds(String modName) {
+  public Map<String, Integer> getFileIds(String modName) {
     return legacyFeaturedModFileRepository.getFileIds(modName);
   }
 

--- a/src/main/java/com/faforever/api/featuredmods/LegacyFeaturedModFileRepository.java
+++ b/src/main/java/com/faforever/api/featuredmods/LegacyFeaturedModFileRepository.java
@@ -103,7 +103,7 @@ public class LegacyFeaturedModFileRepository implements Repository<FeaturedModFi
   }
 
   @SuppressWarnings("unchecked")
-  public Map<String, Short> getFileIds(String modName) {
+  public Map<String, Integer> getFileIds(String modName) {
     // Please shoot me.
     String innerModName = "ladder1v1".equals(modName) ? "faf" : modName;
     verifyModName(innerModName);
@@ -111,7 +111,7 @@ public class LegacyFeaturedModFileRepository implements Repository<FeaturedModFi
     Query query = entityManager.createNativeQuery(String.format("SELECT id, filename FROM updates_%s", innerModName));
 
     return ((List<Object[]>) query.getResultList()).stream()
-      .collect(Collectors.toMap(row -> (String) row[1], row -> (short) row[0]));
+      .collect(Collectors.toMap(row -> (String) row[1], row -> (int) row[0]));
   }
 
   private void verifyModName(String modName) {

--- a/src/test/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTaskTest.java
+++ b/src/test/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTaskTest.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -204,8 +203,8 @@ public class LegacyFeaturedModDeploymentTaskTest {
       new FeaturedMod().setTechnicalName("faf")
     ));
     when(featuredModService.getFileIds("faf")).thenReturn(Map.of(
-      "ForgedAlliance.exe", (short) 1,
-      "someDir.nx3", (short) 2
+      "ForgedAlliance.exe", 1,
+      "someDir.nx3", 2
     ));
 
     Path dummyExe = repositoriesFolder.resolve("TemplateForgedAlliance.exe");
@@ -246,8 +245,8 @@ public class LegacyFeaturedModDeploymentTaskTest {
       new FeaturedMod().setTechnicalName("faf")
     ));
     when(featuredModService.getFileIds("faf")).thenReturn(Map.of(
-      "ForgedAlliance.exe", (short) 1,
-      "someDir.nx3", (short) 2
+      "ForgedAlliance.exe", 1,
+      "someDir.nx3", 2
     ));
 
     dummyExe = repositoriesFolder.resolve("TemplateForgedAlliance.exe");

--- a/src/test/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTaskTest.java
+++ b/src/test/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTaskTest.java
@@ -156,13 +156,13 @@ public class LegacyFeaturedModDeploymentTaskTest {
 
     assertThat(files, containsInAnyOrder(
       allOf(
-        hasProperty("fileId", is((short) 1)),
+        hasProperty("fileId", is(1)),
         hasProperty("md5", is("47df959058cb52fe966ea5936dbd8f4c")),
         hasProperty("name", is("ForgedAlliance.1337.exe")),
         hasProperty("version", is(1337))
       ),
       allOf(
-        hasProperty("fileId", is((short) 2)),
+        hasProperty("fileId", is(2)),
         hasProperty("md5", is(notNullValue())),
         hasProperty("name", is("someDir.1337.nx3")),
         hasProperty("version", is(1337))

--- a/src/test/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTaskTest.java
+++ b/src/test/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTaskTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -138,8 +139,8 @@ public class LegacyFeaturedModDeploymentTaskTest {
       new FeaturedMod().setTechnicalName("faf")
     ));
     when(featuredModService.getFileIds("faf")).thenReturn(Map.of(
-      "ForgedAlliance.exe", (short) 1,
-      "someDir.nx3", (short) 2
+      "ForgedAlliance.exe", 1,
+      "someDir.nx3", 2
     ));
 
     Path dummyExe = repositoriesFolder.resolve("TemplateForgedAlliance.exe");


### PR DESCRIPTION
Also ensure the deployment status is the right length.

Sourced from this error on prod, I suspect so update just turned all numbers from queries into ints
```
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Short (java.lang.Integer and java.lang.Shor
t are in module java.base of loader 'bootstrap')
faf-java-api             |      at com.faforever.api.featuredmods.LegacyFeaturedModFileRepository.lambda$getFileIds$2(LegacyFeaturedModFileRepository.java:114```