### PR TITLE
Exclude user from jsonapi response for account links

### DIFF
--- a/src/inttest/java/com/faforever/api/data/PlayerElideTest.java
+++ b/src/inttest/java/com/faforever/api/data/PlayerElideTest.java
@@ -52,10 +52,17 @@ public class PlayerElideTest extends AbstractIntegrationTest {
       .andExpect(jsonPath("$.data[1].relationships", not(hasKey("uniqueIds"))))
       .andExpect(jsonPath("$.data[2].relationships", not(hasKey("uniqueIds"))))
       .andExpect(jsonPath("$.data[3].relationships", not(hasKey("uniqueIds"))))
+      .andExpect(jsonPath("$.data[0].relationships", not(hasKey("accountLinks"))))
+      .andExpect(jsonPath("$.data[1].relationships", not(hasKey("accountLinks"))))
+      .andExpect(jsonPath("$.data[2].relationships", not(hasKey("accountLinks"))))
+      .andExpect(jsonPath("$.data[3].relationships", not(hasKey("accountLinks"))))
       // you are allowed to see your own stuff
       .andExpect(jsonPath("$.data[4].attributes.email", is("active-user@faforever.com")))
       .andExpect(jsonPath("$.data[4].attributes.recentIpAddress", is("127.0.0.1")))
       .andExpect(jsonPath("$.data[4].attributes", hasKey("lastLogin")))
+      .andExpect(jsonPath("$.data[4].relationships", hasKey("reporterOnModerationReports")))
+      .andExpect(jsonPath("$.data[4].relationships", hasKey("userGroups")))
+      .andExpect(jsonPath("$.data[4].relationships", hasKey("accountLinks")))
       // you cannot see your uuid
       .andExpect(jsonPath("$.data[4].relationships", not(hasKey("uniqueIds"))))
       // nobody can see passwords!
@@ -104,12 +111,17 @@ public class PlayerElideTest extends AbstractIntegrationTest {
       .andExpect(jsonPath("$.data[1].relationships", not(hasKey("uniqueIds"))))
       .andExpect(jsonPath("$.data[2].relationships", not(hasKey("uniqueIds"))))
       .andExpect(jsonPath("$.data[3].relationships", not(hasKey("uniqueIds"))))
+      .andExpect(jsonPath("$.data[0].relationships", not(hasKey("accountLinks"))))
+      .andExpect(jsonPath("$.data[1].relationships", not(hasKey("accountLinks"))))
+      .andExpect(jsonPath("$.data[2].relationships", not(hasKey("accountLinks"))))
+      .andExpect(jsonPath("$.data[3].relationships", not(hasKey("accountLinks"))))
       // you are allowed to see your own stuff
       .andExpect(jsonPath("$.data[4].attributes.email", is("active-user@faforever.com")))
       .andExpect(jsonPath("$.data[4].attributes.recentIpAddress", is("127.0.0.1")))
       .andExpect(jsonPath("$.data[4].attributes", hasKey("lastLogin")))
       .andExpect(jsonPath("$.data[4].relationships", hasKey("reporterOnModerationReports")))
       .andExpect(jsonPath("$.data[4].relationships", hasKey("userGroups")))
+      .andExpect(jsonPath("$.data[4].relationships", hasKey("accountLinks")))
       // you cannot see your uuid
       .andExpect(jsonPath("$.data[4].relationships", not(hasKey("uniqueIds"))))
       // nobody can see passwords!
@@ -162,6 +174,11 @@ public class PlayerElideTest extends AbstractIntegrationTest {
       .andExpect(jsonPath("$.data[2].relationships", hasKey("uniqueIds")))
       .andExpect(jsonPath("$.data[3].relationships", hasKey("uniqueIds")))
       .andExpect(jsonPath("$.data[4].relationships", hasKey("uniqueIds")))
+      .andExpect(jsonPath("$.data[0].relationships", hasKey("accountLinks")))
+      .andExpect(jsonPath("$.data[1].relationships", hasKey("accountLinks")))
+      .andExpect(jsonPath("$.data[2].relationships", hasKey("accountLinks")))
+      .andExpect(jsonPath("$.data[3].relationships", hasKey("accountLinks")))
+      .andExpect(jsonPath("$.data[4].relationships", hasKey("accountLinks")))
       // cannot see others reporterOnModerationReports
       .andExpect(jsonPath("$.data[0].relationships", not(hasKey("reporterOnModerationReports"))))
       .andExpect(jsonPath("$.data[1].relationships", not(hasKey("reporterOnModerationReports"))))

--- a/src/main/java/com/faforever/api/data/domain/AccountLink.java
+++ b/src/main/java/com/faforever/api/data/domain/AccountLink.java
@@ -4,6 +4,7 @@ import com.faforever.api.data.checks.IsEntityOwner;
 import com.faforever.api.data.checks.Prefab;
 import com.faforever.api.security.elide.permission.ReadAccountPrivateDetailsCheck;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
@@ -22,11 +23,12 @@ import javax.persistence.Transient;
 
 @Entity
 @Table(name = "service_links")
-@Include(name = "accountLink")
+@Include(name = AccountLink.TYPE_NAME, rootLevel = false)
 @Setter
 @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + ReadAccountPrivateDetailsCheck.EXPRESSION)
 public class AccountLink implements OwnableEntity {
 
+  public static final String TYPE_NAME = "accountLink";
   private String id;
   private User user;
   private LinkedServiceType serviceType;
@@ -48,6 +50,7 @@ public class AccountLink implements OwnableEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
+  @Exclude
   public User getUser() {
     return user;
   }

--- a/src/main/java/com/faforever/api/data/domain/Login.java
+++ b/src/main/java/com/faforever/api/data/domain/Login.java
@@ -92,6 +92,7 @@ public abstract class Login extends AbstractEntity<Login> implements OwnableEnti
 
   @OneToMany(mappedBy = "user", fetch = FetchType.EAGER)
   @BatchSize(size = 1000)
+  @ReadPermission(expression = IsEntityOwner.EXPRESSION + " OR " + ReadAccountPrivateDetailsCheck.EXPRESSION)
   public Set<AccountLink> getAccountLinks() {
     return this.accountLinks;
   }


### PR DESCRIPTION
User is not included in elide so leads to an NPE when accountLinks are included in any response