### PR TITLE
Add HMAC verification to patch files for cloudflare

### DIFF
--- a/src/inttest/java/com/faforever/api/featuredmods/FeaturedModsControllerTest.java
+++ b/src/inttest/java/com/faforever/api/featuredmods/FeaturedModsControllerTest.java
@@ -1,0 +1,26 @@
+package com.faforever.api.featuredmods;
+
+import com.faforever.api.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:sql/truncateTables.sql")
+@Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:sql/prepDefaultData.sql")
+@Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:sql/prepFeaturedMods.sql")
+public class FeaturedModsControllerTest extends AbstractIntegrationTest {
+
+  @Test
+  public void featuredModFileUrlCorrect() throws Exception {
+    mockMvc.perform(get("/featuredMods/0/files/latest")
+        .with(getOAuthTokenWithActiveUser(NO_SCOPE, NO_AUTHORITIES)))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.data", hasSize(1)))
+      .andExpect(jsonPath("$.data[0].attributes.url", is("USER")));
+  }
+}

--- a/src/inttest/java/com/faforever/api/featuredmods/FeaturedModsControllerTest.java
+++ b/src/inttest/java/com/faforever/api/featuredmods/FeaturedModsControllerTest.java
@@ -1,11 +1,13 @@
 package com.faforever.api.featuredmods;
 
 import com.faforever.api.AbstractIntegrationTest;
+import com.faforever.api.security.OAuthScope;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,11 +18,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class FeaturedModsControllerTest extends AbstractIntegrationTest {
 
   @Test
-  public void featuredModFileUrlCorrect() throws Exception {
+  public void featuredModFileUrlCorrectWithLobbyScope() throws Exception {
     mockMvc.perform(get("/featuredMods/0/files/latest")
-        .with(getOAuthTokenWithActiveUser(NO_SCOPE, NO_AUTHORITIES)))
-      .andExpect(status().isOk())
-      .andExpect(jsonPath("$.data", hasSize(1)))
-      .andExpect(jsonPath("$.data[0].attributes.url", is("USER")));
+             .with(getOAuthTokenWithActiveUser(OAuthScope._LOBBY, NO_AUTHORITIES)))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.data", hasSize(1)))
+           .andExpect(jsonPath("$.data[0].type", is("featuredModFile")))
+           .andExpect(jsonPath("$.data[0].attributes.url", matchesRegex(".*\\?verify=[0-9]+-.*")));
+  }
+
+  @Test
+  public void featuredModFileNotVisibleWithoutLobbyScope() throws Exception {
+    mockMvc.perform(get("/featuredMods/0/files/latest")
+             .with(getOAuthTokenWithActiveUser(NO_SCOPE, NO_AUTHORITIES)))
+           .andExpect(status().isForbidden());
   }
 }

--- a/src/inttest/resources/config/application.yml
+++ b/src/inttest/resources/config/application.yml
@@ -53,6 +53,9 @@ faf-api:
     max-size-bytes: 4096
     image-width: 40
     image-height: 20
+  cloudflare:
+    hmac-secret: "banana"
+    hmac-param: "verify"
   clan:
     website-url-format: "http://example.com/%s"
   tutorial:

--- a/src/inttest/resources/sql/prepFeaturedMods.sql
+++ b/src/inttest/resources/sql/prepFeaturedMods.sql
@@ -1,4 +1,9 @@
 -- game_featuredMods is populated by R__010_game_featuredMods.sql from Flyway
+INSERT INTO `updates_faf` (`id`, `filename`, `path`) VALUES
+(1,	'ForgedAlliance.exe',	'bin');
+
+INSERT INTO `updates_faf_files` (`id`, `fileId`, `version`, `name`, `md5`, `obselete`) VALUES
+(1703,	1,	3706,	'ForgedAlliance.3706.exe',	'c20b922a785cf5876c39b7696a16f162',	0);
 
 INSERT INTO `updates_fafbeta` (`id`, `filename`, `path`) VALUES
 (1,	'ForgedAlliance.exe',	'bin');

--- a/src/main/java/com/faforever/api/config/FafApiProperties.java
+++ b/src/main/java/com/faforever/api/config/FafApiProperties.java
@@ -137,6 +137,7 @@ public class FafApiProperties {
   @Data
   public static class FeaturedMod {
     private String fileUrlFormat;
+    private String cloudflareHmacSecret;
   }
 
   @Data

--- a/src/main/java/com/faforever/api/config/FafApiProperties.java
+++ b/src/main/java/com/faforever/api/config/FafApiProperties.java
@@ -23,6 +23,7 @@ public class FafApiProperties {
   private Replay replay = new Replay();
   private Avatar avatar = new Avatar();
   private Clan clan = new Clan();
+  private Cloudflare cloudflare = new Cloudflare();
   private FeaturedMod featuredMod = new FeaturedMod();
   private GitHub gitHub = new GitHub();
   private Deployment deployment = new Deployment();
@@ -137,13 +138,18 @@ public class FafApiProperties {
   @Data
   public static class FeaturedMod {
     private String fileUrlFormat;
-    private String cloudflareHmacSecret;
   }
 
   @Data
   public static class Clan {
     private long inviteLinkExpireDurationMinutes = Duration.ofDays(7).toMinutes();
     private String websiteUrlFormat;
+  }
+
+  @Data
+  public static class Cloudflare {
+    private String hmacParam;
+    private String hmacSecret;
   }
 
   @Data

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModFileEnricher.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModFileEnricher.java
@@ -2,12 +2,12 @@ package com.faforever.api.featuredmods;
 
 import com.faforever.api.config.FafApiProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
 import javax.persistence.PostLoad;
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -45,6 +45,6 @@ public class FeaturedModFileEnricher {
     String hmacEncoded = URLEncoder.encode(new String(Base64.getEncoder().encode(mac.doFinal(macMessage)), StandardCharsets.UTF_8), StandardCharsets.UTF_8);
     String parameter = "%d-%s".formatted(timeStamp, hmacEncoded);
 
-    featuredModFile.setUrl(UriBuilder.fromUri(featuredModUri).queryParam("verify", parameter).build().toString());
+    featuredModFile.setUrl(UriComponentsBuilder.fromUri(featuredModUri).queryParam("verify", parameter).build().toString());
   }
 }

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModFileEnricher.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModFileEnricher.java
@@ -3,11 +3,23 @@ package com.faforever.api.featuredmods;
 import com.faforever.api.config.FafApiProperties;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
 import javax.persistence.PostLoad;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
 
 @Component
 public class FeaturedModFileEnricher {
+
+  private static final String HMAC_SHA256 = "HmacSHA256";
 
   private static FafApiProperties fafApiProperties;
 
@@ -17,10 +29,22 @@ public class FeaturedModFileEnricher {
   }
 
   @PostLoad
-  public void enhance(FeaturedModFile featuredModFile) {
+  public void enhance(FeaturedModFile featuredModFile) throws NoSuchAlgorithmException, InvalidKeyException {
     String folder = featuredModFile.getFolderName();
     String urlFormat = fafApiProperties.getFeaturedMod().getFileUrlFormat();
+    String secret = fafApiProperties.getFeaturedMod().getCloudflareHmacSecret();
+    long timeStamp = Instant.now().getEpochSecond();
+    URI featuredModUri = URI.create(String.format(urlFormat, folder, featuredModFile.getOriginalFileName()));
 
-    featuredModFile.setUrl(String.format(urlFormat, folder, featuredModFile.getOriginalFileName()));
+    // Builds hmac token for cloudflare firewall verification as specified at
+    // https://support.cloudflare.com/hc/en-us/articles/115001376488-Configuring-Token-Authentication
+    Mac mac = Mac.getInstance(HMAC_SHA256);
+    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+    byte[] macMessage = (featuredModUri.getPath() + timeStamp).getBytes(StandardCharsets.UTF_8);
+
+    String hmacEncoded = URLEncoder.encode(new String(Base64.getEncoder().encode(mac.doFinal(macMessage)), StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+    String parameter = "%d-%s".formatted(timeStamp, hmacEncoded);
+
+    featuredModFile.setUrl(UriBuilder.fromUri(featuredModUri).queryParam("verify", parameter).build().toString());
   }
 }

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModService.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModService.java
@@ -44,6 +44,10 @@ public class FeaturedModService {
     return legacyFeaturedModFileRepository.getFileIds(modName);
   }
 
+  public Optional<FeaturedMod> findModById(int id) {
+    return featuredModRepository.findById(id);
+  }
+
   public Optional<FeaturedMod> findModByTechnicalName(String name) {
     return featuredModRepository.findOneByTechnicalName(name);
   }

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModsController.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModsController.java
@@ -1,12 +1,14 @@
 package com.faforever.api.featuredmods;
 
 import com.faforever.api.data.domain.FeaturedMod;
+import com.faforever.api.security.OAuthScope;
 import com.google.common.collect.Maps;
 import com.yahoo.elide.jsonapi.models.Data;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.jsonapi.models.Resource;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,6 +33,7 @@ public class FeaturedModsController {
   @Async
   @RequestMapping(path = "/{modId}/files/{version}")
   @ApiOperation("Lists the required files for a specific featured mod version")
+  @PreAuthorize("hasScope('" + OAuthScope._LOBBY + "')")
   public CompletableFuture<JsonApiDocument> getFiles(@PathVariable("modId") int modId,
                                                      @PathVariable("version") String version,
                                                      @RequestParam(value = "page[number]", required = false) Integer page) {

--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -22,9 +22,10 @@ faf-api:
     allowed-extensions: ${AVATAR_ALLOWED_FILE_EXTENSIONS:png}
   featured-mod:
     file-url-format: ${FEATURED_MOD_URL_FORMAT:https://localhost/legacy-featured-mod-files/%s/%s}
-    cloudflare-hmac-secret: ${CLOUDFLARE_HMAC_SECRET:banana}
   git-hub:
     deployment-environment: ${GITHUB_DEPLOYMENT_ENVIRONMENT:development}
+  cloudflare:
+    hmac-secret: ${CLOUDFLARE_HMAC_SECRET:banana}
   deployment:
     forged-alliance-exe-path: ${FORGED_ALLIANCE_EXE_PATH}
     repositories-directory: ${REPOSITORIES_DIRECTORY:build/cache/repos}
@@ -73,7 +74,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${JWT_FAF_HYDRA_ISSUER:https://hydra.test.faforever.com/}
+          jwk-set-uri: http://localhost:4444/.well-known/jwks.json
+          issuer-uri: http://faf-ory-hydra:4444/
 logging:
   level:
     com.faforever.api: debug

--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -21,7 +21,8 @@ faf-api:
     target-directory: ${AVATAR_TARGET_DIRECTORY:build/cache/avatars}
     allowed-extensions: ${AVATAR_ALLOWED_FILE_EXTENSIONS:png}
   featured-mod:
-    file-url-format: ${FEATURED_MOD_URL_FORMAT:https://content.test.faforever.com/faf/updaterNew/%s/%s}
+    file-url-format: ${FEATURED_MOD_URL_FORMAT:https://localhost/legacy-featured-mod-files/%s/%s}
+    cloudflare-hmac-secret: ${CLOUDFLARE_HMAC_SECRET:banana}
   git-hub:
     deployment-environment: ${GITHUB_DEPLOYMENT_ENVIRONMENT:development}
   deployment:

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -14,6 +14,9 @@ faf-api:
   clan:
     invite-link-expire-duration-minutes: ${CLAN_INVITE_LINK_EXPIRE_DURATION_MINUTES:604800}
     website-url-format: ${CLAN_WEBSITE_URL_FORMAT:https://clans.${FAF_DOMAIN}/clan/%s}
+  cloudflare:
+    hmac-secret: ${CLOUDFLARE_HMAC_SECRET}
+    hmac-param: ${CLOUDFLARE_HMAC_PARAM:verify}
   database:
     schema-version: ${DATABASE_SCHEMA_VERSION:126}
   deployment:
@@ -25,7 +28,6 @@ faf-api:
     forged-alliance-develop-exe-path: ${EXE_UPLOAD_DEVELOP_PATH:/content/legacy-featured-mod-files/updates_fafdevelop_files}
   featured-mod:
     file-url-format: ${FEATURED_MOD_URL_FORMAT:https://content.${FAF_DOMAIN}/legacy-featured-mod-files/%s/%s}
-    cloudflare-hmac-secret: ${CLOUDFLARE_HMAC_SECRET}
   git-hub:
     access-token: ${GITHUB_ACCESS_TOKEN:false}
     webhook-secret: ${GITHUB_WEBHOOK_SECRET:false}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -25,6 +25,7 @@ faf-api:
     forged-alliance-develop-exe-path: ${EXE_UPLOAD_DEVELOP_PATH:/content/legacy-featured-mod-files/updates_fafdevelop_files}
   featured-mod:
     file-url-format: ${FEATURED_MOD_URL_FORMAT:https://content.${FAF_DOMAIN}/legacy-featured-mod-files/%s/%s}
+    cloudflare-hmac-secret: ${CLOUDFLARE_HMAC_SECRET}
   git-hub:
     access-token: ${GITHUB_ACCESS_TOKEN:false}
     webhook-secret: ${GITHUB_WEBHOOK_SECRET:false}


### PR DESCRIPTION
This adds verification of the patch files using cloudflares hmac authentication token as specified here https://support.cloudflare.com/hc/en-us/articles/115001376488-Configuring-Token-Authentication

This will allow us to limit access to our patch files only to those who have proven game ownership