### PR TITLE
Add Cacheable URLs for FeatureModFiles

### DIFF
--- a/src/inttest/java/com/faforever/api/featuredmods/FeaturedModsControllerTest.java
+++ b/src/inttest/java/com/faforever/api/featuredmods/FeaturedModsControllerTest.java
@@ -5,9 +5,11 @@ import com.faforever.api.security.OAuthScope;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
 
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -24,7 +26,10 @@ public class FeaturedModsControllerTest extends AbstractIntegrationTest {
            .andExpect(status().isOk())
            .andExpect(jsonPath("$.data", hasSize(1)))
            .andExpect(jsonPath("$.data[0].type", is("featuredModFile")))
-           .andExpect(jsonPath("$.data[0].attributes.url", matchesRegex(".*\\?verify=[0-9]+-.*")));
+           .andExpect(jsonPath("$.data[0].attributes", hasKey("hmacParameter")))
+           .andExpect(jsonPath("$.data[0].attributes.url", matchesRegex(".*\\?verify=[0-9]+-.*")))
+           .andExpect(jsonPath("$.data[0].attributes.cacheableUrl", not(matchesRegex(".*\\?.*"))))
+           .andExpect(jsonPath("$.data[0].attributes.hmacToken", matchesRegex("[0-9]+-.*")));
   }
 
   @Test

--- a/src/main/java/com/faforever/api/cloudflare/CloudflareService.java
+++ b/src/main/java/com/faforever/api/cloudflare/CloudflareService.java
@@ -1,0 +1,43 @@
+package com.faforever.api.cloudflare;
+
+import com.faforever.api.config.FafApiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+public class CloudflareService {
+
+  private static final String HMAC_SHA256 = "HmacSHA256";
+
+  private final FafApiProperties fafApiProperties;
+
+  public String generateCloudFlareHmacToken(String featuredModUriString) throws NoSuchAlgorithmException, InvalidKeyException {
+    return generateCloudFlareHmacToken(URI.create(featuredModUriString));
+  }
+
+  public String generateCloudFlareHmacToken(URI featuredModUri) throws NoSuchAlgorithmException, InvalidKeyException {
+    String secret = fafApiProperties.getCloudflare().getHmacSecret();
+    long timeStamp = Instant.now().getEpochSecond();
+
+    // Builds hmac token for cloudflare firewall verification as specified at
+    // https://support.cloudflare.com/hc/en-us/articles/115001376488-Configuring-Token-Authentication
+    Mac mac = Mac.getInstance(HMAC_SHA256);
+    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+    byte[] macMessage = (featuredModUri.getPath() + timeStamp).getBytes(StandardCharsets.UTF_8);
+
+    String hmacEncoded = URLEncoder.encode(new String(Base64.getEncoder().encode(mac.doFinal(macMessage)), StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+    return "%d-%s".formatted(timeStamp, hmacEncoded);
+  }
+
+}

--- a/src/main/java/com/faforever/api/cloudflare/CloudflareService.java
+++ b/src/main/java/com/faforever/api/cloudflare/CloudflareService.java
@@ -22,19 +22,29 @@ public class CloudflareService {
 
   private final FafApiProperties fafApiProperties;
 
-  public String generateCloudFlareHmacToken(String featuredModUriString) throws NoSuchAlgorithmException, InvalidKeyException {
-    return generateCloudFlareHmacToken(URI.create(featuredModUriString));
+  /**
+   * Builds hmac token for cloudflare firewall verification as specified
+   * <a href="https://support.cloudflare.com/hc/en-us/articles/115001376488-Configuring-Token-Authentication">here</a>
+   * @param uri uri to generate the hmac token for
+   * @return string representing the hmac token formatted as {timestamp}-{hashedContent}
+   */
+  public String generateCloudFlareHmacToken(String uri) throws NoSuchAlgorithmException, InvalidKeyException {
+    return generateCloudFlareHmacToken(URI.create(uri));
   }
 
-  public String generateCloudFlareHmacToken(URI featuredModUri) throws NoSuchAlgorithmException, InvalidKeyException {
+  /**
+   * Builds hmac token for cloudflare firewall verification as specified
+   * <a href="https://support.cloudflare.com/hc/en-us/articles/115001376488-Configuring-Token-Authentication">here</a>
+   * @param uri uri to generate the hmac token for
+   * @return string representing the hmac token formatted as {timestamp}-{hashedContent}
+   */
+  public String generateCloudFlareHmacToken(URI uri) throws NoSuchAlgorithmException, InvalidKeyException {
     String secret = fafApiProperties.getCloudflare().getHmacSecret();
     long timeStamp = Instant.now().getEpochSecond();
 
-    // Builds hmac token for cloudflare firewall verification as specified at
-    // https://support.cloudflare.com/hc/en-us/articles/115001376488-Configuring-Token-Authentication
     Mac mac = Mac.getInstance(HMAC_SHA256);
     mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
-    byte[] macMessage = (featuredModUri.getPath() + timeStamp).getBytes(StandardCharsets.UTF_8);
+    byte[] macMessage = (uri.getPath() + timeStamp).getBytes(StandardCharsets.UTF_8);
 
     String hmacEncoded = URLEncoder.encode(new String(Base64.getEncoder().encode(mac.doFinal(macMessage)), StandardCharsets.UTF_8), StandardCharsets.UTF_8);
     return "%d-%s".formatted(timeStamp, hmacEncoded);

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModFile.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModFile.java
@@ -87,21 +87,33 @@ public class FeaturedModFile {
 
   // Enriched by FeaturedModFileEnricher
 
+  /**
+   * URL with hmac token as query parameter for backwards compatibility with clients, cannot be cached by cloudflare
+   */
   @Transient
   public String getUrl() {
     return url;
   }
 
+  /**
+   * URL without any query parameters so it can be cached by cloudflare
+   */
   @Transient
   public String getCacheableUrl() {
     return cacheableUrl;
   }
 
+  /**
+   * Token to be set as header parameter for cloudflare validation
+   */
   @Transient
   public String getHmacToken() {
     return hmacToken;
   }
 
+  /**
+   * Parameter to set the token as
+   */
   @Transient
   public String getHmacParameter() {
     return hmacParameter;

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModFile.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModFile.java
@@ -26,6 +26,9 @@ public class FeaturedModFile {
   private int version;
   // Enriched in FeaturedModFileEnricher
   private String url;
+  private String cacheableUrl;
+  private String hmacToken;
+  private String hmacParameter;
   private String folderName;
   private int fileId;
 
@@ -73,12 +76,6 @@ public class FeaturedModFile {
     return fileId;
   }
 
-  @Transient
-  // Enriched by FeaturedModFileEnricher
-  public String getUrl() {
-    return url;
-  }
-
   /**
    * Returns the name of the folder on the server in which the file resides (e.g. {@code updates_faf_files}). Used by
    * the {@link FeaturedModFileEnricher}.
@@ -86,5 +83,27 @@ public class FeaturedModFile {
   @Column(name = "folderName")
   public String getFolderName() {
     return folderName;
+  }
+
+  // Enriched by FeaturedModFileEnricher
+
+  @Transient
+  public String getUrl() {
+    return url;
+  }
+
+  @Transient
+  public String getCacheableUrl() {
+    return cacheableUrl;
+  }
+
+  @Transient
+  public String getHmacToken() {
+    return hmacToken;
+  }
+
+  @Transient
+  public String getHmacParameter() {
+    return hmacParameter;
   }
 }

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModFileEnricher.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModFileEnricher.java
@@ -1,20 +1,14 @@
 package com.faforever.api.featuredmods;
 
+import com.faforever.api.cloudflare.CloudflareService;
 import com.faforever.api.config.FafApiProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import javax.inject.Inject;
 import javax.persistence.PostLoad;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.time.Instant;
-import java.util.Base64;
 
 @Component
 public class FeaturedModFileEnricher {
@@ -22,30 +16,26 @@ public class FeaturedModFileEnricher {
   private static final String HMAC_SHA256 = "HmacSHA256";
 
   private static FafApiProperties fafApiProperties;
+  private static CloudflareService cloudflareService;
 
   @Inject
-  public void init(FafApiProperties fafApiProperties) {
+  public void init(FafApiProperties fafApiProperties, CloudflareService cloudflareService) {
     FeaturedModFileEnricher.fafApiProperties = fafApiProperties;
+    FeaturedModFileEnricher.cloudflareService = cloudflareService;
   }
 
   @PostLoad
   public void enhance(FeaturedModFile featuredModFile) throws NoSuchAlgorithmException, InvalidKeyException {
     String folder = featuredModFile.getFolderName();
     String urlFormat = fafApiProperties.getFeaturedMod().getFileUrlFormat();
-    String secret = fafApiProperties.getCloudflare().getHmacSecret();
-    long timeStamp = Instant.now().getEpochSecond();
-    URI featuredModUri = URI.create(urlFormat.formatted(folder, featuredModFile.getOriginalFileName()));
+    String urlString = urlFormat.formatted(folder, featuredModFile.getOriginalFileName());
 
-    // Builds hmac token for cloudflare firewall verification as specified at
-    // https://support.cloudflare.com/hc/en-us/articles/115001376488-Configuring-Token-Authentication
-    Mac mac = Mac.getInstance(HMAC_SHA256);
-    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
-    byte[] macMessage = (featuredModUri.getPath() + timeStamp).getBytes(StandardCharsets.UTF_8);
+    String hmacToken = cloudflareService.generateCloudFlareHmacToken(urlString);
+    String hmacParam = fafApiProperties.getCloudflare().getHmacParam();
 
-    String hmacEncoded = URLEncoder.encode(new String(Base64.getEncoder().encode(mac.doFinal(macMessage)), StandardCharsets.UTF_8), StandardCharsets.UTF_8);
-    String parameterValue = "%d-%s".formatted(timeStamp, hmacEncoded);
-
-    String queryParam = fafApiProperties.getCloudflare().getHmacParam();
-    featuredModFile.setUrl(UriComponentsBuilder.fromUri(featuredModUri).queryParam(queryParam, parameterValue).build().toString());
+    featuredModFile.setUrl(UriComponentsBuilder.fromUriString(urlString).queryParam(hmacParam, hmacToken).build().toString());
+    featuredModFile.setCacheableUrl(urlString);
+    featuredModFile.setHmacToken(hmacToken);
+    featuredModFile.setHmacParameter(hmacParam);
   }
 }

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModFileEnricher.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModFileEnricher.java
@@ -7,8 +7,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.inject.Inject;
 import javax.persistence.PostLoad;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 
 @Component
 public class FeaturedModFileEnricher {
@@ -25,7 +23,7 @@ public class FeaturedModFileEnricher {
   }
 
   @PostLoad
-  public void enhance(FeaturedModFile featuredModFile) throws NoSuchAlgorithmException, InvalidKeyException {
+  public void enhance(FeaturedModFile featuredModFile) {
     String folder = featuredModFile.getFolderName();
     String urlFormat = fafApiProperties.getFeaturedMod().getFileUrlFormat();
     String urlString = urlFormat.formatted(folder, featuredModFile.getOriginalFileName());

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModsController.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModsController.java
@@ -8,6 +8,7 @@ import com.yahoo.elide.jsonapi.models.Data;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.jsonapi.models.Resource;
 import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,13 +24,10 @@ import static com.faforever.api.error.ErrorCode.FEATURED_MOD_UNKNOWN;
 
 @RestController
 @RequestMapping(path = "/featuredMods")
+@RequiredArgsConstructor
 public class FeaturedModsController {
 
   private final FeaturedModService featuredModService;
-
-  public FeaturedModsController(FeaturedModService featuredModService) {
-    this.featuredModService = featuredModService;
-  }
 
   @RequestMapping(path = "/{modId}/files/{version}")
   @ApiOperation("Lists the required files for a specific featured mod version")
@@ -61,6 +59,9 @@ public class FeaturedModsController {
         "md5", file.getMd5(),
         "name", file.getName(),
         "url", file.getUrl(),
+        "cacheableUrl", file.getCacheableUrl(),
+        "hmacToken", file.getHmacToken(),
+        "hmacParameter", file.getHmacParameter(),
         "version", file.getVersion()
       ), null, null, null);
   }

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModsController.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModsController.java
@@ -3,13 +3,11 @@ package com.faforever.api.featuredmods;
 import com.faforever.api.data.domain.FeaturedMod;
 import com.faforever.api.error.ApiException;
 import com.faforever.api.error.Error;
-import com.faforever.api.security.OAuthScope;
 import com.yahoo.elide.jsonapi.models.Data;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.jsonapi.models.Resource;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,7 +29,7 @@ public class FeaturedModsController {
 
   @RequestMapping(path = "/{modId}/files/{version}")
   @ApiOperation("Lists the required files for a specific featured mod version")
-  @PreAuthorize("hasScope('" + OAuthScope._LOBBY + "')")
+//  @PreAuthorize("hasScope('" + OAuthScope._LOBBY + "')")
   public JsonApiDocument getFiles(@PathVariable("modId") int modId,
                                   @PathVariable("version") String version,
                                   @RequestParam(value = "page[number]", required = false) Integer page) {

--- a/src/main/java/com/faforever/api/featuredmods/FeaturedModsController.java
+++ b/src/main/java/com/faforever/api/featuredmods/FeaturedModsController.java
@@ -3,11 +3,13 @@ package com.faforever.api.featuredmods;
 import com.faforever.api.data.domain.FeaturedMod;
 import com.faforever.api.error.ApiException;
 import com.faforever.api.error.Error;
+import com.faforever.api.security.OAuthScope;
 import com.yahoo.elide.jsonapi.models.Data;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.jsonapi.models.Resource;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -29,7 +31,7 @@ public class FeaturedModsController {
 
   @RequestMapping(path = "/{modId}/files/{version}")
   @ApiOperation("Lists the required files for a specific featured mod version")
-//  @PreAuthorize("hasScope('" + OAuthScope._LOBBY + "')")
+  @PreAuthorize("hasScope('" + OAuthScope._LOBBY + "')")
   public JsonApiDocument getFiles(@PathVariable("modId") int modId,
                                   @PathVariable("version") String version,
                                   @RequestParam(value = "page[number]", required = false) Integer page) {

--- a/src/test/java/com/faforever/api/cloudflare/CloudflareServiceTest.java
+++ b/src/test/java/com/faforever/api/cloudflare/CloudflareServiceTest.java
@@ -1,0 +1,49 @@
+package com.faforever.api.cloudflare;
+
+import com.faforever.api.config.FafApiProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CloudflareServiceTest {
+
+  private static final String HMAC_SHA256 = "HmacSHA256";
+
+  @Mock
+  private FafApiProperties fafApiProperties;
+  @InjectMocks
+  private CloudflareService instance;
+
+  @Test
+  public void hmacTokenGeneration() throws Exception {
+    String secret = "foo";
+    FafApiProperties.Cloudflare cloudflare = new FafApiProperties.Cloudflare();
+    cloudflare.setHmacSecret(secret);
+
+    when(fafApiProperties.getCloudflare()).thenReturn(cloudflare);
+
+    String token = instance.generateCloudFlareHmacToken("http://example.com/bar");
+
+    String[] tokenParts = token.split("-");
+    String timeStamp = tokenParts[0];
+
+    Mac mac = Mac.getInstance(HMAC_SHA256);
+    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+    byte[] macMessage = ("/bar" + timeStamp).getBytes(StandardCharsets.UTF_8);
+
+    String hmacEncoded = URLEncoder.encode(new String(Base64.getEncoder().encode(mac.doFinal(macMessage)), StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+    assertEquals(hmacEncoded, tokenParts[1]);
+  }
+}

--- a/src/test/java/com/faforever/api/cloudflare/CloudflareServiceTest.java
+++ b/src/test/java/com/faforever/api/cloudflare/CloudflareServiceTest.java
@@ -1,10 +1,9 @@
 package com.faforever.api.cloudflare;
 
 import com.faforever.api.config.FafApiProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.crypto.Mac;
@@ -14,33 +13,32 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CloudflareServiceTest {
 
   private static final String HMAC_SHA256 = "HmacSHA256";
 
-  @Mock
-  private FafApiProperties fafApiProperties;
-  @InjectMocks
+  private FafApiProperties fafApiProperties = new FafApiProperties();
   private CloudflareService instance;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    String secret = "foo";
+    fafApiProperties.getCloudflare().setHmacSecret(secret);
+
+    instance = new CloudflareService(fafApiProperties);
+  }
 
   @Test
   public void hmacTokenGeneration() throws Exception {
-    String secret = "foo";
-    FafApiProperties.Cloudflare cloudflare = new FafApiProperties.Cloudflare();
-    cloudflare.setHmacSecret(secret);
-
-    when(fafApiProperties.getCloudflare()).thenReturn(cloudflare);
-
     String token = instance.generateCloudFlareHmacToken("http://example.com/bar");
 
     String[] tokenParts = token.split("-");
     String timeStamp = tokenParts[0];
 
     Mac mac = Mac.getInstance(HMAC_SHA256);
-    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+    mac.init(new SecretKeySpec(fafApiProperties.getCloudflare().getHmacSecret().getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
     byte[] macMessage = ("/bar" + timeStamp).getBytes(StandardCharsets.UTF_8);
 
     String hmacEncoded = URLEncoder.encode(new String(Base64.getEncoder().encode(mac.doFinal(macMessage)), StandardCharsets.UTF_8), StandardCharsets.UTF_8);


### PR DESCRIPTION
This adds separation of the hmac token, param, and a cacheable url so that clients can send the hmac verification as a request header which allows caching of the request in cloudflare since there is no longer any query parameters