### PR TITLE
Add gameId column to LeagueScoreJournal

### DIFF
--- a/src/inttest/java/com/faforever/api/config/LeagueDbTestContainers.java
+++ b/src/inttest/java/com/faforever/api/config/LeagueDbTestContainers.java
@@ -20,7 +20,7 @@ import javax.sql.DataSource;
 @Configuration
 public class LeagueDbTestContainers {
   private static final MariaDBContainer<?> leagueServiceDBContainer = new MariaDBContainer<>("mariadb:10.6");
-  private static final GenericContainer<?> leagueServiceContainer = new GenericContainer<>("faforever/faf-league-service:1.3.0");
+  private static final GenericContainer<?> leagueServiceContainer = new GenericContainer<>("faforever/faf-league-service:1.5.0");
   private static final Network sharedNetwork = Network.newNetwork();
 
   @Bean

--- a/src/inttest/java/com/faforever/api/league/LeaderboardElideTest.java
+++ b/src/inttest/java/com/faforever/api/league/LeaderboardElideTest.java
@@ -28,7 +28,7 @@ class LeaderboardElideTest extends AbstractIntegrationTest {
       get("/data/leagueLeaderboard")
     )
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.data[*]", hasSize(5)));
+      .andExpect(jsonPath("$.data[*]", hasSize(6)));
   }
 
   @Test

--- a/src/inttest/java/com/faforever/api/league/LeagueScoreJournalElideTest.java
+++ b/src/inttest/java/com/faforever/api/league/LeagueScoreJournalElideTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.jdbc.SqlConfig;
 
 import static com.faforever.api.data.JsonApiMediaType.JSON_API_MEDIA_TYPE;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -43,7 +44,15 @@ public class LeagueScoreJournalElideTest extends AbstractIntegrationTest {
     mockMvc.perform(
         get("/data/leagueScoreJournal/1")
       )
-      .andExpect(status().isOk());
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.data.attributes.gameId", is(2)))
+      .andExpect(jsonPath("$.data.attributes.loginId", is(1)))
+      .andExpect(jsonPath("$.data.attributes.leagueSeasonId", is(1)))
+      .andExpect(jsonPath("$.data.attributes.subdivisionIdBefore", is(1)))
+      .andExpect(jsonPath("$.data.attributes.subdivisionIdAfter", is(2)))
+      .andExpect(jsonPath("$.data.attributes.scoreBefore", is(10)))
+      .andExpect(jsonPath("$.data.attributes.scoreAfter", is(2)))
+      .andExpect(jsonPath("$.data.attributes.gameCount", is(22)));
   }
 
   @Test
@@ -57,6 +66,7 @@ public class LeagueScoreJournalElideTest extends AbstractIntegrationTest {
             "data": {
               "type": "leagueScoreJournal",
               "attributes": {
+                "gameId": 10,
                 "gameCount": 10,
                 "loginId": 10,
                 "scoreBefore": 10,

--- a/src/inttest/java/com/faforever/api/league/LeagueScoreJournalElideTest.java
+++ b/src/inttest/java/com/faforever/api/league/LeagueScoreJournalElideTest.java
@@ -47,9 +47,9 @@ public class LeagueScoreJournalElideTest extends AbstractIntegrationTest {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.data.attributes.gameId", is(2)))
       .andExpect(jsonPath("$.data.attributes.loginId", is(1)))
-      .andExpect(jsonPath("$.data.attributes.leagueSeasonId", is(1)))
-      .andExpect(jsonPath("$.data.attributes.subdivisionIdBefore", is(1)))
-      .andExpect(jsonPath("$.data.attributes.subdivisionIdAfter", is(2)))
+      .andExpect(jsonPath("$.data.relationships.leagueSeason.data.id", is(1)))
+      .andExpect(jsonPath("$.data.relationships.leagueSeasonDivisionSubdivisionBefore.data.id", is(1)))
+      .andExpect(jsonPath("$.data.relationships.leagueSeasonDivisionSubdivisionAfter.data.id", is(2)))
       .andExpect(jsonPath("$.data.attributes.scoreBefore", is(10)))
       .andExpect(jsonPath("$.data.attributes.scoreAfter", is(2)))
       .andExpect(jsonPath("$.data.attributes.gameCount", is(22)));

--- a/src/inttest/java/com/faforever/api/league/LeagueScoreJournalElideTest.java
+++ b/src/inttest/java/com/faforever/api/league/LeagueScoreJournalElideTest.java
@@ -47,9 +47,9 @@ public class LeagueScoreJournalElideTest extends AbstractIntegrationTest {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.data.attributes.gameId", is(2)))
       .andExpect(jsonPath("$.data.attributes.loginId", is(1)))
-      .andExpect(jsonPath("$.data.relationships.leagueSeason.data.id", is(1)))
-      .andExpect(jsonPath("$.data.relationships.leagueSeasonDivisionSubdivisionBefore.data.id", is(1)))
-      .andExpect(jsonPath("$.data.relationships.leagueSeasonDivisionSubdivisionAfter.data.id", is(2)))
+      .andExpect(jsonPath("$.data.relationships.leagueSeason.data.id", is("1")))
+      .andExpect(jsonPath("$.data.relationships.leagueSeasonDivisionSubdivisionBefore.data.id", is("1")))
+      .andExpect(jsonPath("$.data.relationships.leagueSeasonDivisionSubdivisionAfter.data.id", is("2")))
       .andExpect(jsonPath("$.data.attributes.scoreBefore", is(10)))
       .andExpect(jsonPath("$.data.attributes.scoreAfter", is(2)))
       .andExpect(jsonPath("$.data.attributes.gameCount", is(22)));

--- a/src/inttest/resources/sql/league/prepLeagueData.sql
+++ b/src/inttest/resources/sql/league/prepLeagueData.sql
@@ -34,9 +34,9 @@ VALUES (1, 1, 1, 1, 10, 10, FALSE),
        (7, 1, 2, 7, 22, 20, FALSE),
        (8, 1, 2, 8, 23, 20, FALSE);
 
-INSERT INTO league_score_journal (id, login_id, league_season_id, subdivision_id_before, subdivision_id_after,
+INSERT INTO league_score_journal (id, game_id, login_id, league_season_id, subdivision_id_before, subdivision_id_after,
                                   score_before, score_after, game_count)
-VALUES (1, 1, 1, 1, 2, 10, 2, 22),
-       (2, 1, 1, 2, 2, 2, 3, 23),
-       (3, 5, 1, 3, 3, 7, 6, 11),
-       (4, 5, 1, 3, 3, 6, 5, 12);
+VALUES (1, 2, 1, 1, 1, 2, 10, 2, 22),
+       (2, 2, 1, 1, 2, 2, 2, 3, 23),
+       (3, 2, 5, 1, 3, 3, 7, 6, 11),
+       (4, 2, 5, 1, 3, 3, 6, 5, 12);

--- a/src/main/java/com/faforever/api/league/domain/LeagueScoreJournal.java
+++ b/src/main/java/com/faforever/api/league/domain/LeagueScoreJournal.java
@@ -20,6 +20,7 @@ public class LeagueScoreJournal {
   public static final String TYPE_NAME = "leagueScoreJournal";
 
   private Integer id;
+  private Integer gameId;
   private Integer loginId;
   private LeagueSeason leagueSeason;
   private LeagueSeasonDivisionSubdivision leagueSeasonDivisionSubdivisionBefore;
@@ -33,6 +34,11 @@ public class LeagueScoreJournal {
   @Column(name = "id")
   public Integer getId() {
     return id;
+  }
+
+  @Column(name = "game_id")
+  public Integer getGameId() {
+    return gameId;
   }
 
   @Column(name = "login_id")


### PR DESCRIPTION
Requires league service 1.5.0

With this the loginId and gameId just exist as integers. They don't have a relationship to the actual object with that Id. How can this be added given that we would cross databases with this?