### PR TITLE
Closes #818 Send 404 instead of 500 for NoResourceFoundException

### DIFF
--- a/src/main/java/com/faforever/api/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/faforever/api/error/GlobalControllerExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.faforever.api.error;
 
+import jakarta.servlet.ServletException;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
@@ -64,12 +66,26 @@ class GlobalControllerExceptionHandler {
     ));
   }
 
-  @ExceptionHandler({HttpRequestMethodNotSupportedException.class, NoResourceFoundException.class, NotFoundApiException.class})
+  @ExceptionHandler(NotFoundApiException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ResponseBody
   public ErrorResponse processNotFoundException(NotFoundApiException ex) {
     log.debug("Entity could not be found", ex);
     return createResponseFromApiException(ex, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler({HttpRequestMethodNotSupportedException.class, NoResourceFoundException.class})
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  @ResponseBody
+  public ErrorResponse processResourceNotFoundException(ServletException ex) {
+    log.debug("Resource could not be found", ex);
+    ErrorResponse response = new ErrorResponse();
+    response.addError(new ErrorResult(
+      String.valueOf(HttpStatus.NOT_FOUND.value()),
+      HttpStatus.NOT_FOUND.getReasonPhrase(),
+      ex.getMessage()
+    ));
+    return response;
   }
 
   @ExceptionHandler(ApiException.class)

--- a/src/main/java/com/faforever/api/error/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/faforever/api/error/GlobalControllerExceptionHandler.java
@@ -5,6 +5,7 @@ import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,6 +16,9 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.ValidationException;
+
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.concurrent.CompletionException;
@@ -60,7 +64,7 @@ class GlobalControllerExceptionHandler {
     ));
   }
 
-  @ExceptionHandler(NotFoundApiException.class)
+  @ExceptionHandler({HttpRequestMethodNotSupportedException.class, NoResourceFoundException.class, NotFoundApiException.class})
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ResponseBody
   public ErrorResponse processNotFoundException(NotFoundApiException ex) {


### PR DESCRIPTION
Closes #818 - Send 404 instead of 500 for NoResourceFoundException

Added the exceptions to the `GlobalControllerExceptionHandler` -> 404 is returned.