### PR TITLE
Closes #820 Improve handling of failed steam redirect validations

### DIFF
--- a/src/main/java/com/faforever/api/error/ErrorCode.java
+++ b/src/main/java/com/faforever/api/error/ErrorCode.java
@@ -117,6 +117,7 @@ public enum ErrorCode {
   LESS_PERMISSIVE_LICENSE(207, "Less permissive license", "New license is less permissive than current license."),
   MALFORMED_URL(208, "Malformed URL", "Provided url ''{0}'' is malformed."),
   NOT_ALLOWED_URL_HOST(209, "URL host not allowed", "Provided URL's host is not allowed. URL: ''{0}'', allowed hosts: ''{1}''."),
+  STEAM_LOGIN_VALIDATION_FAILED(210, "Login via Steam failed", "Invalid OpenID redirect code"),
   ;
 
 

--- a/src/test/java/com/faforever/api/user/SteamServiceTest.java
+++ b/src/test/java/com/faforever/api/user/SteamServiceTest.java
@@ -11,8 +11,6 @@ import com.faforever.api.data.domain.User;
 import com.faforever.api.error.ApiException;
 import com.faforever.api.error.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,8 +34,6 @@ class SteamServiceTest {
 
   @Test
   void testHandleInvalidOpenIdRedirect() {
-    when(requestMock.getParameterMap())
-        .thenReturn(Map.of(IDENTITY_NAME_PARAM, new String[]{DUMMY_URL}));
     when(requestMock.getParameter(IDENTITY_NAME_PARAM)).thenReturn(DUMMY_URL);
 
     ApiException thrownException = assertThrows(ApiException.class,
@@ -49,8 +45,6 @@ class SteamServiceTest {
   @Test
   void testHandleInvalidOpenIdRedirectBlankIdentityParam() {
     final String blankDummyUrl = "";
-    when(requestMock.getParameterMap())
-        .thenReturn(Map.of(IDENTITY_NAME_PARAM, new String[]{blankDummyUrl}));
     when(requestMock.getParameter(IDENTITY_NAME_PARAM)).thenReturn(blankDummyUrl);
 
     ApiException thrownException = assertThrows(ApiException.class,
@@ -61,8 +55,6 @@ class SteamServiceTest {
 
   @Test
   void testHandleInvalidOpenIdRedirectNoIdentityInRequest() {
-    when(requestMock.getParameterMap()).thenReturn(Collections.emptyMap());
-
     ApiException thrownException = assertThrows(ApiException.class,
         () -> beanUnderTest.handleInvalidOpenIdRedirect(requestMock, DUMMY_RESPONSE));
     assertEquals(ErrorCode.STEAM_LOGIN_VALIDATION_FAILED,
@@ -76,8 +68,6 @@ class SteamServiceTest {
     when(userMock.getLogin()).thenReturn("dummyLogin");
     AccountLink accountLinkMock = Mockito.mock(AccountLink.class);
     when(accountLinkMock.getUser()).thenReturn(userMock);
-    when(requestMock.getParameterMap())
-        .thenReturn(Map.of(IDENTITY_NAME_PARAM, new String[]{DUMMY_URL}));
     when(requestMock.getParameter(IDENTITY_NAME_PARAM)).thenReturn(DUMMY_URL);
     when(accountLinkRepositoryMock.findOneByServiceIdAndServiceType(anyString(),
         any(LinkedServiceType.class))).thenReturn(

--- a/src/test/java/com/faforever/api/user/SteamServiceTest.java
+++ b/src/test/java/com/faforever/api/user/SteamServiceTest.java
@@ -1,0 +1,94 @@
+package com.faforever.api.user;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.faforever.api.data.domain.AccountLink;
+import com.faforever.api.data.domain.LinkedServiceType;
+import com.faforever.api.data.domain.User;
+import com.faforever.api.error.ApiException;
+import com.faforever.api.error.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SteamServiceTest {
+
+  private static final String IDENTITY_NAME_PARAM = "openid.identity";
+  private static final String DUMMY_URL = "valid.url.domain/login/123";
+  private static final String DUMMY_RESPONSE = "dummy response";
+  @Mock
+  private AccountLinkRepository accountLinkRepositoryMock;
+  @InjectMocks
+  private SteamService beanUnderTest;
+
+  @Test
+  void testHandleInvalidOpenIdRedirect() {
+    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    when(requestMock.getParameterMap())
+        .thenReturn(Map.of(IDENTITY_NAME_PARAM, new String[]{DUMMY_URL}));
+    when(requestMock.getParameter(IDENTITY_NAME_PARAM)).thenReturn(DUMMY_URL);
+
+    ApiException thrownException = assertThrows(ApiException.class,
+        () -> beanUnderTest.handleInvalidOpenIdRedirect(requestMock, DUMMY_RESPONSE));
+    assertEquals(ErrorCode.STEAM_LOGIN_VALIDATION_FAILED,
+        thrownException.getErrors()[0].getErrorCode());
+  }
+
+  @Test
+  void testHandleInvalidOpenIdRedirectBlankIdentityParam() {
+    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    final String blankDummyUrl = "";
+    when(requestMock.getParameterMap())
+        .thenReturn(Map.of(IDENTITY_NAME_PARAM, new String[]{blankDummyUrl}));
+    when(requestMock.getParameter(IDENTITY_NAME_PARAM)).thenReturn(blankDummyUrl);
+
+    ApiException thrownException = assertThrows(ApiException.class,
+        () -> beanUnderTest.handleInvalidOpenIdRedirect(requestMock, DUMMY_RESPONSE));
+    assertEquals(ErrorCode.STEAM_LOGIN_VALIDATION_FAILED,
+        thrownException.getErrors()[0].getErrorCode());
+  }
+
+  @Test
+  void testHandleInvalidOpenIdRedirectNoIdentityInRequest() {
+    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    when(requestMock.getParameterMap()).thenReturn(Collections.emptyMap());
+
+    ApiException thrownException = assertThrows(ApiException.class,
+        () -> beanUnderTest.handleInvalidOpenIdRedirect(requestMock, DUMMY_RESPONSE));
+    assertEquals(ErrorCode.STEAM_LOGIN_VALIDATION_FAILED,
+        thrownException.getErrors()[0].getErrorCode());
+  }
+
+  @Test
+  void testHandleInvalidOpenIdRedirectLinkedAccountExists() {
+    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
+    User userMock = Mockito.mock(User.class);
+    when(userMock.getId()).thenReturn(1);
+    when(userMock.getLogin()).thenReturn("dummyLogin");
+    AccountLink accountLinkMock = Mockito.mock(AccountLink.class);
+    when(accountLinkMock.getUser()).thenReturn(userMock);
+    when(requestMock.getParameterMap())
+        .thenReturn(Map.of(IDENTITY_NAME_PARAM, new String[]{DUMMY_URL}));
+    when(requestMock.getParameter(IDENTITY_NAME_PARAM)).thenReturn(DUMMY_URL);
+    when(accountLinkRepositoryMock.findOneByServiceIdAndServiceType(anyString(),
+        any(LinkedServiceType.class))).thenReturn(
+        Optional.of(accountLinkMock));
+
+    ApiException thrownException = assertThrows(ApiException.class,
+        () -> beanUnderTest.handleInvalidOpenIdRedirect(requestMock, DUMMY_RESPONSE));
+    assertEquals(ErrorCode.STEAM_LOGIN_VALIDATION_FAILED,
+        thrownException.getErrors()[0].getErrorCode());
+  }
+
+}

--- a/src/test/java/com/faforever/api/user/SteamServiceTest.java
+++ b/src/test/java/com/faforever/api/user/SteamServiceTest.java
@@ -29,12 +29,13 @@ class SteamServiceTest {
   private static final String DUMMY_RESPONSE = "dummy response";
   @Mock
   private AccountLinkRepository accountLinkRepositoryMock;
+  @Mock
+  private HttpServletRequest requestMock;
   @InjectMocks
   private SteamService beanUnderTest;
 
   @Test
   void testHandleInvalidOpenIdRedirect() {
-    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
     when(requestMock.getParameterMap())
         .thenReturn(Map.of(IDENTITY_NAME_PARAM, new String[]{DUMMY_URL}));
     when(requestMock.getParameter(IDENTITY_NAME_PARAM)).thenReturn(DUMMY_URL);
@@ -47,7 +48,6 @@ class SteamServiceTest {
 
   @Test
   void testHandleInvalidOpenIdRedirectBlankIdentityParam() {
-    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
     final String blankDummyUrl = "";
     when(requestMock.getParameterMap())
         .thenReturn(Map.of(IDENTITY_NAME_PARAM, new String[]{blankDummyUrl}));
@@ -61,7 +61,6 @@ class SteamServiceTest {
 
   @Test
   void testHandleInvalidOpenIdRedirectNoIdentityInRequest() {
-    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
     when(requestMock.getParameterMap()).thenReturn(Collections.emptyMap());
 
     ApiException thrownException = assertThrows(ApiException.class,
@@ -72,7 +71,6 @@ class SteamServiceTest {
 
   @Test
   void testHandleInvalidOpenIdRedirectLinkedAccountExists() {
-    HttpServletRequest requestMock = Mockito.mock(HttpServletRequest.class);
     User userMock = Mockito.mock(User.class);
     when(userMock.getId()).thenReturn(1);
     when(userMock.getLogin()).thenReturn("dummyLogin");


### PR DESCRIPTION
Closes #820 
Note: I have implemented `SteamService#handleInvalidOpenIdRedirect` method, whit the mindset that the validation fails because an attacker tries to exploit the endpoint.