### PR TITLE
Allow exposing data to anonymous users as config option

### DIFF
--- a/src/main/java/com/faforever/api/config/FafApiProperties.java
+++ b/src/main/java/com/faforever/api/config/FafApiProperties.java
@@ -16,6 +16,7 @@ public class FafApiProperties {
    * The API version.
    */
   private String version;
+  private boolean allowAnonymous;
   private Jwt jwt = new Jwt();
   private OAuth2 oAuth2 = new OAuth2();
   private Async async = new Async();
@@ -256,11 +257,6 @@ public class FafApiProperties {
     private Integer port;
     private String user;
     private String password;
-  }
-
-  @Data
-  public static class Anope {
-    private String databaseName;
   }
 
   @Data

--- a/src/main/java/com/faforever/api/config/security/MethodSecurityConfig.java
+++ b/src/main/java/com/faforever/api/config/security/MethodSecurityConfig.java
@@ -1,12 +1,18 @@
 package com.faforever.api.config.security;
 
 import com.faforever.api.security.method.CustomMethodSecurityExpressionHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 @Configuration
+@ConditionalOnProperty(
+        value = "faf-api.allow-anonymous",
+        havingValue = "false",
+        matchIfMissing = true
+)
 @EnableMethodSecurity(securedEnabled = true)
 public class MethodSecurityConfig {
   @Bean

--- a/src/main/java/com/faforever/api/security/ElideUser.java
+++ b/src/main/java/com/faforever/api/security/ElideUser.java
@@ -24,7 +24,7 @@ public class ElideUser extends User {
 
   @Override
   public boolean isInRole(String role) {
-    return fafAuthentication.hasRole(role);
+    return fafAuthentication != null && fafAuthentication.hasRole(role);
   }
 
   public Optional<Integer> getFafUserId() {

--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -1,4 +1,5 @@
 faf-api:
+  allow-anonymous: true
   jwt:
     secretKeyPath: ${JWT_PRIVATE_KEY_PATH:test-pki-private.key}
     publicKeyPath: ${JWT_PUBLIC_KEY_PATH:test-pki-public.key}
@@ -86,8 +87,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: https://hydra.faforever.com/.well-known/jwks.json
-          issuer-uri: https://hydra.faforever.com/
+          jwk-set-uri: http://hydra.faforever.localhost/.well-known/jwks.json
+          issuer-uri: http://ory-hydra:4444/
 logging:
   level:
     com.faforever.api: debug


### PR DESCRIPTION
Also add other security config changes to support development with gitops-stack tilt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `faf-api.allow-anonymous` configuration to control anonymous access.
  * When enabled, `/data/**` can be accessed without authentication.

* **Bug Fixes**
  * Improved role checking to safely handle unauthenticated/anonymous requests without errors.

* **Chores**
  * Updated local development configuration to enable anonymous access and use local Hydra endpoints for OAuth2 JWT (issuer/JWKS) settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->