### PR TITLE
Permit unauthenticated access to health/info/prometheus actuator endpoints

### DIFF
--- a/src/main/java/com/faforever/api/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/faforever/api/config/security/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.faforever.api.config.security;
 
 import com.faforever.api.security.FafAuthenticationConverter;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -37,6 +38,7 @@ public class WebSecurityConfig {
     });
     http.authorizeHttpRequests(authorizeConfig -> {
       authorizeConfig.requestMatchers(HttpMethod.OPTIONS).permitAll();
+      authorizeConfig.requestMatchers(EndpointRequest.to("health", "info", "prometheus")).permitAll();
       // Swagger UI
       authorizeConfig.requestMatchers(
         "/swagger-ui/**",

--- a/src/main/java/com/faforever/api/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/faforever/api/config/security/WebSecurityConfig.java
@@ -1,7 +1,7 @@
 package com.faforever.api.config.security;
 
 import com.faforever.api.security.FafAuthenticationConverter;
-import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.security.autoconfigure.actuate.web.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;


### PR DESCRIPTION
## Summary
- Spring Boot 4 applies the application's `SecurityFilterChain` to the management port, so the existing `anyRequest().authenticated()` rule made `/actuator/health` return 401 and broke the prod deployment's healthcheck.
- Permit `health`, `info`, and `prometheus` via `EndpointRequest.to(...)`; other exposed endpoints (`env`, `beans`, …) still require authentication.

## Test plan
- [ ] Deploy to prod and confirm the healthcheck on the management port (8011) succeeds
- [ ] `curl http://<host>:8011/actuator/health` returns 200 without credentials
- [ ] `curl http://<host>:8011/actuator/env` still returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the security configuration to allow unauthenticated access to operational endpoints, including service health, basic info, and Prometheus metrics. This improves observability and simplifies status/monitoring checks without requiring login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->