### PR TITLE
Allow null steps in AchievementUpdateRequest

### DIFF
--- a/src/main/java/com/faforever/api/achievements/AchievementUpdateRequest.java
+++ b/src/main/java/com/faforever/api/achievements/AchievementUpdateRequest.java
@@ -1,10 +1,13 @@
 package com.faforever.api.achievements;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 record AchievementUpdateRequest(
   int playerId,
   String achievementId,
   Operation operation,
-  int steps
+  @Schema(description = "Required for INCREMENT and SET_STEPS_AT_LEAST; ignored (and may be null/omitted) for REVEAL and UNLOCK.", nullable = true)
+  Integer steps
 ) {
   public enum Operation {
     REVEAL, UNLOCK, INCREMENT, SET_STEPS_AT_LEAST

--- a/src/main/java/com/faforever/api/achievements/AchievementsController.java
+++ b/src/main/java/com/faforever/api/achievements/AchievementsController.java
@@ -21,9 +21,16 @@ public class AchievementsController {
     switch (request.operation()) {
       case REVEAL -> throw new UnsupportedOperationException("REVEAL is not yet implemented");
       case UNLOCK -> achievementService.unlock(request.playerId(), request.achievementId());
-      case INCREMENT -> achievementService.increment(request.playerId(), request.achievementId(), request.steps());
+      case INCREMENT -> achievementService.increment(request.playerId(), request.achievementId(), requireSteps(request));
       case SET_STEPS_AT_LEAST ->
-        achievementService.setStepsAtLeast(request.playerId(), request.achievementId(), request.steps());
+        achievementService.setStepsAtLeast(request.playerId(), request.achievementId(), requireSteps(request));
     }
+  }
+
+  private static int requireSteps(AchievementUpdateRequest request) {
+    if (request.steps() == null) {
+      throw new IllegalArgumentException("steps is required for operation " + request.operation());
+    }
+    return request.steps();
   }
 }


### PR DESCRIPTION
## Summary
- Achievement processing broke after the Spring Boot 4 / Jackson 3 upgrade: incoming `request.achievement.update` messages with no `steps` field (sent for `REVEAL`/`UNLOCK` operations) are rejected as `MismatchedInputException: Cannot map null into type int`, turning them into poison messages that block the queue.
- Jackson 3 flipped `FAIL_ON_NULL_FOR_PRIMITIVES` to `true` by default and treats absent JSON properties as `null` for primitive record components. Jackson 2 silently coerced these to `0`, masking the latent contract gap.
- Switch `steps` to `Integer` and annotate it with `@Schema(nullable = true, description = ...)` to document that it is only required for `INCREMENT` and `SET_STEPS_AT_LEAST`. The controller only unboxes `steps()` on those two paths, so no NPE risk.

## Test plan
- [ ] Republish a `REVEAL`/`UNLOCK` message (no `steps` field) and confirm it is consumed without `MessageConversionException`.
- [ ] Republish an `INCREMENT` / `SET_STEPS_AT_LEAST` message and confirm the steps value is applied as before.
- [ ] Confirm the achievement queue drains and is no longer stuck on the poison message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced OpenAPI/Swagger documentation for achievement update API endpoints with improved field metadata and clarity.

* **API Changes**
  * The `steps` parameter in achievement update requests is now properly marked as optional for REVEAL and UNLOCK operations, and required for INCREMENT and SET_STEPS_AT_LEAST operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->