### PR TITLE
Add COOP_DEPLOYER role to UserRole enum

### DIFF
--- a/src/main/java/com/faforever/api/security/UserRole.java
+++ b/src/main/java/com/faforever/api/security/UserRole.java
@@ -9,7 +9,8 @@ import java.util.Optional;
 public enum UserRole implements GrantedAuthority {
   USER("USER"),
   MODERATOR("MODERATOR"),
-  ADMINISTRATOR("ADMINISTRATOR");
+  ADMINISTRATOR("ADMINISTRATOR"),
+  COOP_DEPLOYER("COOP_DEPLOYER");
 
   private static final Map<String, UserRole> fromString;
 


### PR DESCRIPTION
## Summary

Adds the `COOP_DEPLOYER` role to the `UserRole` enum.

This role is required for the new `faf-coop-deployer` service
(https://github.com/TimMasalme/coop-deployer), which replaces the manual
Kotlin scripts run by Brutus/Sheikah for co-op map and patch deployment.

Users with this role can trigger map and patch deployments via a REST API
instead of requiring direct database and shell access.

## How to assign the role

Once this is merged, the COOP_DEPLOYER group can be created and managed
via the existing User Groups tab in Mordor — no further UI changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "COOP_DEPLOYER" role, enabling expanded authorization capabilities within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->