### PR TITLE
Make map folderName an indexable column to fix slow map filters

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
       - "3306:3306"
 
   faf-db-migrations:
-    image: faforever/faf-db-migrations:v140
+    image: faforever/faf-db-migrations:v144
     command: migrate
     environment:
       FLYWAY_URL: jdbc:mysql://faf-db/faf?useSSL=false
@@ -35,7 +35,7 @@ services:
         condition: service_completed_successfully
 
   minio:
-    image: docker.io/bitnami/minio:2025
+    image: docker.io/alpine/minio:latest-release
     ports:
       - '9000:9000'
       - '9001:9001'

--- a/src/inttest/java/com/faforever/api/config/MainDbTestContainers.java
+++ b/src/inttest/java/com/faforever/api/config/MainDbTestContainers.java
@@ -21,7 +21,7 @@ import javax.sql.DataSource;
 @Configuration
 public class MainDbTestContainers {
   private static final MariaDBContainer<?> fafDBContainer = new MariaDBContainer<>("mariadb:11.7");
-  private static final GenericContainer<?> flywayMigrationsContainer = new GenericContainer<>("faforever/faf-db-migrations:v140");
+  private static final GenericContainer<?> flywayMigrationsContainer = new GenericContainer<>("faforever/faf-db-migrations:v144");
   private static final Network sharedNetwork = Network.newNetwork();
 
   @Bean

--- a/src/inttest/resources/sql/prepMapData.sql
+++ b/src/inttest/resources/sql/prepMapData.sql
@@ -2,9 +2,9 @@ INSERT INTO map (id, display_name, map_type, battle_type, author, license) VALUE
   (1, 'SCMP_001', 'FFA', 'skirmish', 1, 1),
   (2, 'SCMP_002', 'FFA', 'skirmish', 1, 1);
 
-INSERT INTO map_version (id, description, max_players, width, height, version, filename, hidden, map_id) VALUES
-  (1, 'SCMP 001', 8, 5, 5, 1, 'maps/scmp_001.v0001.zip', 0, 1),
-  (2, 'SCMP 002', 8, 5, 5, 1, 'maps/scmp_002.v0001.zip', 0, 2);
+INSERT INTO map_version (id, description, max_players, width, height, version, folder_name, hidden, map_id) VALUES
+  (1, 'SCMP 001', 8, 5, 5, 1, 'scmp_001.v0001', 0, 1),
+  (2, 'SCMP 002', 8, 5, 5, 1, 'scmp_002.v0001', 0, 2);
 
 INSERT INTO map_pool (id, name) VALUES
   (1, 'Ladder 1v1 <300'),

--- a/src/inttest/resources/sql/prepMapVersion.sql
+++ b/src/inttest/resources/sql/prepMapVersion.sql
@@ -1,6 +1,6 @@
 INSERT INTO map (id, display_name, map_type, battle_type, author, recommended, license) VALUES (1, 'display name', 'mtype', 'btype', 1, false, 1);
-INSERT INTO map_version (id, description, max_players, width, height, version, filename, map_id, hidden, ranked)
-VALUES (1, 'des', 2, 2, 2, 1, 'map/ghb.zip', 1, 0, 1);
+INSERT INTO map_version (id, description, max_players, width, height, version, folder_name, map_id, hidden, ranked)
+VALUES (1, 'des', 2, 2, 2, 1, 'ghb', 1, 0, 1);
 INSERT INTO map_reviews_summary (id, map_id, positive, negative, score, reviews, lower_bound)
 VALUES (1, 1, 0, 0, 2, 1, 0);
 INSERT INTO map_version_reviews_summary (id, map_version_id, positive, negative, score, reviews, lower_bound)

--- a/src/main/java/com/faforever/api/data/domain/MapVersion.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersion.java
@@ -142,7 +142,9 @@ public class MapVersion extends AbstractEntity<MapVersion> implements OwnableEnt
     return downloadUrl;
   }
 
-  @Column(name = "folder_name")
+  // Immutable after insert: the DB-generated filename and the derived download/
+  // thumbnail URLs are all computed from this, so it must not change post-creation.
+  @Column(name = "folder_name", updatable = false)
   @NotNull
   public String getFolderName() {
     return folderName;

--- a/src/main/java/com/faforever/api/data/domain/MapVersion.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersion.java
@@ -11,6 +11,8 @@ import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
 import lombok.Setter;
+import org.hibernate.annotations.Generated;
+import org.hibernate.generator.EventType;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -82,7 +84,8 @@ public class MapVersion extends AbstractEntity<MapVersion> implements OwnableEnt
     return version;
   }
 
-  @Column(name = "filename")
+  @Column(name = "filename", insertable = false, updatable = false)
+  @Generated(event = EventType.INSERT)
   @NotNull
   public String getFilename() {
     return filename;
@@ -138,8 +141,8 @@ public class MapVersion extends AbstractEntity<MapVersion> implements OwnableEnt
     return downloadUrl;
   }
 
-  @Transient
-  @ComputedAttribute
+  @Column(name = "folder_name")
+  @NotNull
   public String getFolderName() {
     return folderName;
   }

--- a/src/main/java/com/faforever/api/data/domain/MapVersion.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersion.java
@@ -84,9 +84,10 @@ public class MapVersion extends AbstractEntity<MapVersion> implements OwnableEnt
     return version;
   }
 
+  // DB-generated from folderName (CONCAT('maps/', folder_name, '.zip')); read-only here.
+  // No @NotNull: bean validation runs pre-insert before the DB populates this value.
   @Column(name = "filename", insertable = false, updatable = false)
   @Generated(event = EventType.INSERT)
-  @NotNull
   public String getFilename() {
     return filename;
   }

--- a/src/main/java/com/faforever/api/data/listeners/MapVersionEnricher.java
+++ b/src/main/java/com/faforever/api/data/listeners/MapVersionEnricher.java
@@ -25,11 +25,10 @@ public class MapVersionEnricher {
 
   @PostLoad
   public void enhance(MapVersion mapVersion) {
-    String filename = mapVersion.getFilename();
-    mapVersion.setDownloadUrl(String.format(apiProperties.getMap().getDownloadUrlFormat(), filename.replace("maps/", "")));
-    mapVersion.setThumbnailUrlLarge(String.format(apiProperties.getMap().getLargePreviewsUrlFormat(), filename.replace("maps/", "").replace(".zip", ".png")));
-    mapVersion.setThumbnailUrlSmall(String.format(apiProperties.getMap().getSmallPreviewsUrlFormat(), filename.replace("maps/", "").replace(".zip", ".png")));
-    mapVersion.setFolderName(filename.substring(filename.indexOf('/') + 1, filename.indexOf(".zip")));
+    String folderName = mapVersion.getFolderName();
+    mapVersion.setDownloadUrl(String.format(apiProperties.getMap().getDownloadUrlFormat(), folderName + ".zip"));
+    mapVersion.setThumbnailUrlLarge(String.format(apiProperties.getMap().getLargePreviewsUrlFormat(), folderName + ".png"));
+    mapVersion.setThumbnailUrlSmall(String.format(apiProperties.getMap().getSmallPreviewsUrlFormat(), folderName + ".png"));
   }
 
   @PostUpdate

--- a/src/main/java/com/faforever/api/map/MapService.java
+++ b/src/main/java/com/faforever/api/map/MapService.java
@@ -85,7 +85,6 @@ public class MapService {
   };
 
   private static final Charset MAP_CHARSET = StandardCharsets.ISO_8859_1;
-  private static final String LEGACY_FOLDER_PREFIX = "maps/";
   private final FafApiProperties fafApiProperties;
   private final MapRepository mapRepository;
   private final LicenseRepository licenseRepository;
@@ -413,7 +412,7 @@ public class MapService {
       .setMaxPlayers(standardTeamsConfig.get(CONFIGURATION_STANDARD_TEAMS_ARMIES).length())
       .setVersion(mapLua.getMapVersion$())
       .setMap(map)
-      .setFilename(LEGACY_FOLDER_PREFIX + mapNameBuilder.buildFinalZipName(mapLua.getMapVersion$()));
+      .setFolderName(mapNameBuilder.buildFolderName(mapLua.getMapVersion$()));
 
     map.getVersions().add(version);
 

--- a/src/test/java/com/faforever/api/map/MapServiceTest.java
+++ b/src/test/java/com/faforever/api/map/MapServiceTest.java
@@ -410,7 +410,7 @@ public class MapServiceTest {
       assertEquals(256, mapVersion.getHeight());
       assertEquals(256, mapVersion.getWidth());
       assertEquals(8, mapVersion.getMaxPlayers());
-      assertEquals("maps/command_conquer_rush.v0007.zip", mapVersion.getFilename());
+      assertEquals("command_conquer_rush.v0007", mapVersion.getFolderName());
 
       assertFalse(Files.exists(tmpDir));
 


### PR DESCRIPTION
## Why

Every `/data/map` request that filters on `versions.folderName` takes a flat ~5s (e.g. the client's "find latest version by folder name" lookup, and game searches by map). Root cause: `folderName` was a `@Transient @ComputedAttribute` derived in-memory from `filename` in a `@PostLoad` enricher, so Elide **cannot** translate `versions.folderName == X` into SQL. It fell back to loading and enriching the **entire** `map_version` table on every request and filtering in memory — constant cost regardless of which map is requested.

## What

- `MapVersion.folderName` is now a real `@Column(name = "folder_name")` (was transient/computed), so `versions.folderName == X` becomes a sargable, indexed SQL predicate.
- `MapVersion.filename` becomes a DB-generated column: `@Generated(event = INSERT)`, read-only in the entity. It is kept (value unchanged: `maps/<folder>.zip`) purely for backwards compatibility — see below.
- Upload path (`MapService`) now sets `folderName` instead of `filename`; the enricher derives the download/thumbnail URLs from `folderName` directly (identical output).
- Test fixtures and the migrations image pin bumped to `v144`.

## Requires faf-db PR

Depends on **FAForever/db#332** (adds `map_version.folder_name`, makes `filename` a `VIRTUAL` generated column). This PR's integration tests pin `faforever/faf-db-migrations:v144`, so that image must be released first.

## Backwards compatibility (verified, no changes needed in those repos)

`filename` is retained as a generated column so all external readers keep seeing the identical `maps/<folder>.zip`:
- **faf-server** — `game_service.get_map()`, `ladder_service.fetch_map_pools()`, coop lookups.
- **faf-rust-replayserver** — `get_game_stat_row` selects `map_version.filename`.
- **downlords-faf-client** — never reads `filename`; depends on `folderName`/`downloadUrl`/thumbnails, all preserved. The attribute name `folderName` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar changes are now tracked more directly, improving updates when players change their selected avatar.
  * Map uploads and map display data now use folder-based naming, which should improve map URL and thumbnail handling.
* **Bug Fixes**
  * Updated container versions used for database migrations and map-related test data to match the new map naming format.
* **Chores**
  * Added a helper script to build and publish branch-specific Docker images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->